### PR TITLE
Make UtilUUIDType work more reliably

### DIFF
--- a/querydsl-sql/src/main/java/com/querydsl/sql/types/UtilUUIDType.java
+++ b/querydsl-sql/src/main/java/com/querydsl/sql/types/UtilUUIDType.java
@@ -51,7 +51,7 @@ public class UtilUUIDType extends AbstractType<UUID> {
       String str = rs.getString(startIndex);
       return str != null ? UUID.fromString(str) : null;
     } else {
-      return (UUID) rs.getObject(startIndex);
+      return rs.getObject(startIndex, UUID.class);
     }
   }
 


### PR DESCRIPTION
mssql-jdbc knows how to return UUID, but if you don't specify a type, it returns String