### PR TITLE
changed EntityType#properties to use LinkedHashSet instead of TreeSet  @lpandzic

### DIFF
--- a/querydsl-apt/src/main/java/com/querydsl/apt/ExtendedTypeFactory.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/ExtendedTypeFactory.java
@@ -29,8 +29,8 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -61,10 +61,10 @@ import org.jetbrains.annotations.Nullable;
  */
 public class ExtendedTypeFactory {
 
-  private final Map<List<String>, Type> typeCache = new HashMap<List<String>, Type>();
+  private final Map<List<String>, Type> typeCache = new LinkedHashMap<List<String>, Type>();
 
   private final Map<List<String>, EntityType> entityTypeCache =
-      new HashMap<List<String>, EntityType>();
+      new LinkedHashMap<List<String>, EntityType>();
 
   private final Type defaultType;
 

--- a/querydsl-apt/src/main/java/com/querydsl/apt/TypeElementHandler.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/TypeElementHandler.java
@@ -29,8 +29,8 @@ import com.querydsl.core.util.BeanUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,10 +71,10 @@ public class TypeElementHandler {
     EntityType entityType = typeFactory.getEntityType(element.asType(), true);
     List<? extends Element> elements = element.getEnclosedElements();
     VisitorConfig config = configuration.getConfig(element, elements);
-    Set<String> blockedProperties = new HashSet<String>();
-    Map<String, TypeMirror> propertyTypes = new HashMap<String, TypeMirror>();
-    Map<String, TypeMirror> fixedTypes = new HashMap<String, TypeMirror>();
-    Map<String, Annotations> propertyAnnotations = new HashMap<String, Annotations>();
+    Set<String> blockedProperties = new LinkedHashSet<String>();
+    Map<String, TypeMirror> propertyTypes = new LinkedHashMap<String, TypeMirror>();
+    Map<String, TypeMirror> fixedTypes = new LinkedHashMap<String, TypeMirror>();
+    Map<String, Annotations> propertyAnnotations = new LinkedHashMap<String, Annotations>();
 
     // constructors
     if (config.visitConstructors()) {

--- a/querydsl-apt/src/main/java/com/querydsl/apt/TypeUtils.java
+++ b/querydsl-apt/src/main/java/com/querydsl/apt/TypeUtils.java
@@ -14,11 +14,15 @@
 package com.querydsl.apt;
 
 import java.lang.annotation.Annotation;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.lang.model.element.*;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
@@ -68,7 +72,7 @@ public final class TypeUtils {
   @SuppressWarnings("unchecked")
   public static Set<TypeElement> getAnnotationValuesAsElements(
       AnnotationMirror mirror, String method) {
-    Set<TypeElement> elements = new HashSet<TypeElement>();
+    Set<TypeElement> elements = new LinkedHashSet<TypeElement>();
     for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
         mirror.getElementValues().entrySet()) {
       if (entry.getKey().getSimpleName().toString().equals(method)) {

--- a/querydsl-apt/src/test/java/com/querydsl/apt/GenericExporterTest.java
+++ b/querydsl-apt/src/test/java/com/querydsl/apt/GenericExporterTest.java
@@ -46,6 +46,7 @@ public class GenericExporterTest extends AbstractProcessorTest {
     expected.add("QQueryProjectionTest_EntityWithProjection.java");
     expected.add("QEmbeddable3Test_EmbeddableClass.java");
     expected.add("QQueryEmbedded4Test_User.java");
+    expected.add("QReservedNamesTest_ReservedNames.java");
 
     execute(expected, "GenericExporterTest", "QuerydslAnnotationProcessor");
   }

--- a/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/TypeCategory.java
+++ b/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/TypeCategory.java
@@ -13,7 +13,7 @@
  */
 package com.querydsl.codegen.utils.model;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -75,7 +75,7 @@ public enum TypeCategory {
 
   TypeCategory(TypeCategory superType, String... types) {
     this.superType = superType;
-    this.types = new HashSet<String>(types.length);
+    this.types = new LinkedHashSet<String>(types.length);
     for (String type : types) {
       this.types.add(type);
     }

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Function;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,7 +43,7 @@ public class EntityType extends TypeAdapter implements Comparable<EntityType> {
 
   private final Set<Delegate> delegates = new HashSet<Delegate>();
 
-  private final Set<Property> properties = new TreeSet<Property>();
+  private final Set<Property> properties = new LinkedHashSet<>();
 
   private final Set<String> propertyNames = new HashSet<String>();
 

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/EntityType.java
@@ -20,6 +20,7 @@ import com.querydsl.codegen.utils.model.TypeAdapter;
 import com.querydsl.codegen.utils.model.TypeCategory;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -45,7 +46,7 @@ public class EntityType extends TypeAdapter implements Comparable<EntityType> {
 
   private final Set<Property> properties = new LinkedHashSet<>();
 
-  private final Set<String> propertyNames = new HashSet<String>();
+  private final Set<String> propertyNames = new LinkedHashSet<String>();
 
   private final Set<String> escapedPropertyNames = new HashSet<String>();
 
@@ -182,7 +183,7 @@ public class EntityType extends TypeAdapter implements Comparable<EntityType> {
   }
 
   public Set<Property> getProperties() {
-    return properties;
+    return Collections.unmodifiableSet(properties);
   }
 
   @Nullable

--- a/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
+++ b/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
@@ -55,6 +55,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -255,7 +257,7 @@ public class GenericExporter {
     // add constructors and properties
     for (Map<Class<?>, EntityType> entries :
         Arrays.asList(superTypes, embeddableTypes, entityTypes, projectionTypes)) {
-      for (Map.Entry<Class<?>, EntityType> entry : new HashSet<>(entries.entrySet())) {
+      for (Map.Entry<Class<?>, EntityType> entry : new LinkedHashSet<>(entries.entrySet())) {
         addConstructors(entry.getKey(), entry.getValue());
         addProperties(entry.getKey(), entry.getValue());
       }
@@ -410,7 +412,7 @@ public class GenericExporter {
   }
 
   private void addProperties(Class<?> cl, EntityType type) {
-    Map<String, Type> types = new HashMap<>();
+    Map<String, Type> types = new LinkedHashMap<>();
     Map<String, Annotations> annotations = new HashMap<>();
 
     PropertyHandling.Config config = propertyHandling.getConfig(cl);

--- a/querydsl-core/src/main/java/com/querydsl/core/util/ConstructorUtils.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/util/ConstructorUtils.java
@@ -22,9 +22,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -212,7 +212,7 @@ public final class ConstructorUtils {
 
     PrimitiveTransformer(Constructor<?> constructor) {
       super(constructor);
-      Set<Integer> builder = new TreeSet<>();
+      Set<Integer> builder = new LinkedHashSet<>();
       Class<?>[] parameterTypes = constructor.getParameterTypes();
       for (int location = 0; location < parameterTypes.length; location++) {
         Class<?> parameterType = parameterTypes[location];

--- a/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/JPADomainExporter.java
+++ b/querydsl-jpa-codegen/src/main/java/com/querydsl/jpa/codegen/JPADomainExporter.java
@@ -21,12 +21,18 @@ import com.querydsl.codegen.utils.model.SimpleType;
 import com.querydsl.codegen.utils.model.Type;
 import com.querydsl.codegen.utils.model.TypeCategory;
 import jakarta.persistence.Temporal;
-import jakarta.persistence.metamodel.*;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.EmbeddableType;
+import jakarta.persistence.metamodel.ManagedType;
+import jakarta.persistence.metamodel.MapAttribute;
+import jakarta.persistence.metamodel.MappedSuperclassType;
+import jakarta.persistence.metamodel.Metamodel;
+import jakarta.persistence.metamodel.PluralAttribute;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
 import java.nio.charset.Charset;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.xml.stream.XMLStreamException;
 import org.hibernate.MappingException;
@@ -159,7 +165,7 @@ public class JPADomainExporter extends AbstractDomainExporter {
   protected void collectTypes()
       throws IOException, XMLStreamException, ClassNotFoundException, NoSuchMethodException {
 
-    Map<ManagedType<?>, EntityType> types = new HashMap<>();
+    Map<ManagedType<?>, EntityType> types = new LinkedHashMap<>();
     for (ManagedType<?> managedType : metamodel.getManagedTypes()) {
       if (managedType instanceof MappedSuperclassType) {
         types.put(managedType, createSuperType(managedType.getJavaType()));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SAccount_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SAccount_.java
@@ -19,9 +19,9 @@ public class SAccount_ extends com.querydsl.sql.RelationalPathBase<SAccount_> {
 
   public final NumberPath<Long> id = createNumber("id", Long.class);
 
-  public final NumberPath<Long> ownerI = createNumber("ownerI", Long.class);
-
   public final StringPath somedata = createString("somedata");
+
+  public final NumberPath<Long> ownerI = createNumber("ownerI", Long.class);
 
   public final com.querydsl.sql.PrimaryKey<SAccount_> primary = createPrimaryKey(id);
 
@@ -57,9 +57,9 @@ public class SAccount_ extends com.querydsl.sql.RelationalPathBase<SAccount_> {
     addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
-        ownerI, ColumnMetadata.named("OWNER_I").withIndex(3).ofType(Types.BIGINT).withSize(19));
-    addMetadata(
         somedata,
         ColumnMetadata.named("SOMEDATA").withIndex(2).ofType(Types.VARCHAR).withSize(255));
+    addMetadata(
+        ownerI, ColumnMetadata.named("OWNER_I").withIndex(3).ofType(Types.BIGINT).withSize(19));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SAnimal.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SAnimal.java
@@ -9,13 +9,13 @@ import com.querydsl.sql.ColumnMetadata;
 import java.sql.Types;
 import javax.annotation.processing.Generated;
 
-/** SAnimal_ is a Querydsl query type for SAnimal_ */
+/** SAnimal is a Querydsl query type for SAnimal */
 @Generated("com.querydsl.sql.codegen.MetaDataSerializer")
-public class SAnimal_ extends com.querydsl.sql.RelationalPathBase<SAnimal_> {
+public class SAnimal extends com.querydsl.sql.RelationalPathBase<SAnimal> {
 
-  private static final long serialVersionUID = 2052848731;
+  private static final long serialVersionUID = 343315588;
 
-  public static final SAnimal_ animal_ = new SAnimal_("animal_");
+  public static final SAnimal animal = new SAnimal("animal");
 
   public final NumberPath<Integer> id = createNumber("id", Integer.class);
 
@@ -48,48 +48,35 @@ public class SAnimal_ extends com.querydsl.sql.RelationalPathBase<SAnimal_> {
 
   public final NumberPath<Integer> mateId = createNumber("mateId", Integer.class);
 
-  public final com.querydsl.sql.PrimaryKey<SAnimal_> primary = createPrimaryKey(id);
+  public final com.querydsl.sql.PrimaryKey<SAnimal> primary = createPrimaryKey(id);
 
-  public final com.querydsl.sql.ForeignKey<SAnimal_> animal_MATEIDFK =
-      createForeignKey(mateId, "ID");
+  public final com.querydsl.sql.ForeignKey<SAnimal> animalMATEIDFK = createForeignKey(mateId, "ID");
 
-  public final com.querydsl.sql.ForeignKey<SAnimal_> _animal_MATEIDFK =
+  public final com.querydsl.sql.ForeignKey<SAnimal> _animalMATEIDFK =
       createInvForeignKey(id, "MATE_ID");
 
-  public final com.querydsl.sql.ForeignKey<SKittens> _kittensCatIdFK =
-      createInvForeignKey(id, "cat_id");
-
-  public final com.querydsl.sql.ForeignKey<SKittens> _kittensKittenIdFK =
-      createInvForeignKey(id, "kitten_id");
-
-  public final com.querydsl.sql.ForeignKey<SKittensSet> _kittensSetCatIdFK =
-      createInvForeignKey(id, "cat_id");
-
-  public final com.querydsl.sql.ForeignKey<SKittensSet> _kittensSetKittenIdFK =
-      createInvForeignKey(id, "kitten_id");
-
-  public SAnimal_(String variable) {
-    super(SAnimal_.class, forVariable(variable), "null", "animal_");
+  public SAnimal(String variable) {
+    super(SAnimal.class, forVariable(variable), "null", "animal");
     addMetadata();
   }
 
-  public SAnimal_(String variable, String schema, String table) {
-    super(SAnimal_.class, forVariable(variable), schema, table);
+  public SAnimal(String variable, String schema, String table) {
+    super(SAnimal.class, forVariable(variable), schema, table);
     addMetadata();
   }
 
-  public SAnimal_(String variable, String schema) {
-    super(SAnimal_.class, forVariable(variable), schema, "animal_");
+  public SAnimal(String variable, String schema) {
+    super(SAnimal.class, forVariable(variable), schema, "animal");
     addMetadata();
   }
 
-  public SAnimal_(Path<? extends SAnimal_> path) {
-    super(path.getType(), path.getMetadata(), "null", "animal_");
+  public SAnimal(Path<? extends SAnimal> path) {
+    super(path.getType(), path.getMetadata(), "null", "animal");
     addMetadata();
   }
 
-  public SAnimal_(PathMetadata metadata) {
-    super(SAnimal_.class, metadata, "null", "animal_");
+  public SAnimal(PathMetadata metadata) {
+    super(SAnimal.class, metadata, "null", "animal");
     addMetadata();
   }
 

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SBar_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SBar_.java
@@ -17,9 +17,9 @@ public class SBar_ extends com.querydsl.sql.RelationalPathBase<SBar_> {
 
   public static final SBar_ bar_ = new SBar_("bar_");
 
-  public final DatePath<java.sql.Date> date = createDate("date", java.sql.Date.class);
-
   public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
+  public final DatePath<java.sql.Date> date = createDate("date", java.sql.Date.class);
 
   public final com.querydsl.sql.PrimaryKey<SBar_> primary = createPrimaryKey(id);
 
@@ -49,8 +49,8 @@ public class SBar_ extends com.querydsl.sql.RelationalPathBase<SBar_> {
   }
 
   public void addMetadata() {
-    addMetadata(date, ColumnMetadata.named("DATE").withIndex(2).ofType(Types.DATE).withSize(10));
     addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
+    addMetadata(date, ColumnMetadata.named("DATE").withIndex(2).ofType(Types.DATE).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SBookBookmarks.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SBookBookmarks.java
@@ -18,15 +18,15 @@ public class SBookBookmarks extends com.querydsl.sql.RelationalPathBase<SBookBoo
 
   public static final SBookBookmarks bookBookmarks = new SBookBookmarks("book_bookmarks");
 
-  public final NumberPath<Long> bookidIdentity = createNumber("bookidIdentity", Long.class);
-
-  public final NumberPath<Integer> bookMarksORDER = createNumber("bookMarksORDER", Integer.class);
-
   public final StringPath comment = createString("comment");
+
+  public final NumberPath<Long> page = createNumber("page", Long.class);
 
   public final NumberPath<Long> libraryIdentity = createNumber("libraryIdentity", Long.class);
 
-  public final NumberPath<Long> page = createNumber("page", Long.class);
+  public final NumberPath<Long> bookidIdentity = createNumber("bookidIdentity", Long.class);
+
+  public final NumberPath<Integer> bookMarksORDER = createNumber("bookMarksORDER", Integer.class);
 
   public final com.querydsl.sql.ForeignKey<SBookversion_> bookBookmarksBOOKIDIDENTITYFK =
       createForeignKey(
@@ -60,16 +60,16 @@ public class SBookBookmarks extends com.querydsl.sql.RelationalPathBase<SBookBoo
 
   public void addMetadata() {
     addMetadata(
+        comment, ColumnMetadata.named("COMMENT").withIndex(1).ofType(Types.VARCHAR).withSize(255));
+    addMetadata(page, ColumnMetadata.named("PAGE").withIndex(2).ofType(Types.BIGINT).withSize(19));
+    addMetadata(
+        libraryIdentity,
+        ColumnMetadata.named("LIBRARY_IDENTITY").withIndex(3).ofType(Types.BIGINT).withSize(19));
+    addMetadata(
         bookidIdentity,
         ColumnMetadata.named("BOOKID_IDENTITY").withIndex(4).ofType(Types.BIGINT).withSize(19));
     addMetadata(
         bookMarksORDER,
         ColumnMetadata.named("bookMarks_ORDER").withIndex(5).ofType(Types.INTEGER).withSize(10));
-    addMetadata(
-        comment, ColumnMetadata.named("COMMENT").withIndex(1).ofType(Types.VARCHAR).withSize(255));
-    addMetadata(
-        libraryIdentity,
-        ColumnMetadata.named("LIBRARY_IDENTITY").withIndex(3).ofType(Types.BIGINT).withSize(19));
-    addMetadata(page, ColumnMetadata.named("PAGE").withIndex(2).ofType(Types.BIGINT).withSize(19));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SBook_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SBook_.java
@@ -17,13 +17,13 @@ public class SBook_ extends com.querydsl.sql.RelationalPathBase<SBook_> {
 
   public static final SBook_ book_ = new SBook_("book_");
 
-  public final NumberPath<Long> authorId = createNumber("authorId", Long.class);
+  public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final StringPath dtype = createString("dtype");
 
-  public final NumberPath<Long> id = createNumber("id", Long.class);
-
   public final StringPath title = createString("title");
+
+  public final NumberPath<Long> authorId = createNumber("authorId", Long.class);
 
   public final com.querydsl.sql.PrimaryKey<SBook_> primary = createPrimaryKey(id);
 
@@ -57,12 +57,12 @@ public class SBook_ extends com.querydsl.sql.RelationalPathBase<SBook_> {
 
   public void addMetadata() {
     addMetadata(
-        authorId, ColumnMetadata.named("AUTHOR_ID").withIndex(4).ofType(Types.BIGINT).withSize(19));
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         dtype, ColumnMetadata.named("DTYPE").withIndex(2).ofType(Types.VARCHAR).withSize(31));
     addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
-    addMetadata(
         title, ColumnMetadata.named("TITLE").withIndex(3).ofType(Types.VARCHAR).withSize(255));
+    addMetadata(
+        authorId, ColumnMetadata.named("AUTHOR_ID").withIndex(4).ofType(Types.BIGINT).withSize(19));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SBookversion_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SBookversion_.java
@@ -18,13 +18,13 @@ public class SBookversion_ extends com.querydsl.sql.RelationalPathBase<SBookvers
 
   public static final SBookversion_ bookversion_ = new SBookversion_("bookversion_");
 
-  public final NumberPath<Long> bookidIdentity = createNumber("bookidIdentity", Long.class);
-
   public final StringPath description = createString("description");
 
-  public final NumberPath<Long> libraryIdentity = createNumber("libraryIdentity", Long.class);
-
   public final StringPath name = createString("name");
+
+  public final NumberPath<Long> bookidIdentity = createNumber("bookidIdentity", Long.class);
+
+  public final NumberPath<Long> libraryIdentity = createNumber("libraryIdentity", Long.class);
 
   public final com.querydsl.sql.PrimaryKey<SBookversion_> primary =
       createPrimaryKey(bookidIdentity, libraryIdentity);
@@ -67,6 +67,11 @@ public class SBookversion_ extends com.querydsl.sql.RelationalPathBase<SBookvers
 
   public void addMetadata() {
     addMetadata(
+        description,
+        ColumnMetadata.named("DESCRIPTION").withIndex(1).ofType(Types.VARCHAR).withSize(255));
+    addMetadata(
+        name, ColumnMetadata.named("NAME").withIndex(2).ofType(Types.VARCHAR).withSize(255));
+    addMetadata(
         bookidIdentity,
         ColumnMetadata.named("BOOKID_IDENTITY")
             .withIndex(3)
@@ -74,16 +79,11 @@ public class SBookversion_ extends com.querydsl.sql.RelationalPathBase<SBookvers
             .withSize(19)
             .notNull());
     addMetadata(
-        description,
-        ColumnMetadata.named("DESCRIPTION").withIndex(1).ofType(Types.VARCHAR).withSize(255));
-    addMetadata(
         libraryIdentity,
         ColumnMetadata.named("LIBRARY_IDENTITY")
             .withIndex(4)
             .ofType(Types.BIGINT)
             .withSize(19)
             .notNull());
-    addMetadata(
-        name, ColumnMetadata.named("NAME").withIndex(2).ofType(Types.VARCHAR).withSize(255));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCatalog_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCatalog_.java
@@ -17,10 +17,10 @@ public class SCatalog_ extends com.querydsl.sql.RelationalPathBase<SCatalog_> {
 
   public static final SCatalog_ catalog_ = new SCatalog_("catalog_");
 
+  public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
   public final DatePath<java.sql.Date> effectivedate =
       createDate("effectivedate", java.sql.Date.class);
-
-  public final NumberPath<Integer> id = createNumber("id", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SCatalog_> primary = createPrimaryKey(id);
 
@@ -54,9 +54,9 @@ public class SCatalog_ extends com.querydsl.sql.RelationalPathBase<SCatalog_> {
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
+    addMetadata(
         effectivedate,
         ColumnMetadata.named("EFFECTIVEDATE").withIndex(2).ofType(Types.DATE).withSize(10));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCategory_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCategory_.java
@@ -17,6 +17,8 @@ public class SCategory_ extends com.querydsl.sql.RelationalPathBase<SCategory_> 
 
   public static final SCategory_ category_ = new SCategory_("category_");
 
+  public final NumberPath<Long> id = createNumber("id", Long.class);
+
   public final StringPath categorydescription = createString("categorydescription");
 
   public final StringPath categoryname = createString("categoryname");
@@ -30,8 +32,6 @@ public class SCategory_ extends com.querydsl.sql.RelationalPathBase<SCategory_> 
       createDateTime("deletedate", java.sql.Timestamp.class);
 
   public final NumberPath<Double> deletedby = createNumber("deletedby", Double.class);
-
-  public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final DateTimePath<java.sql.Timestamp> modificationdate =
       createDateTime("modificationdate", java.sql.Timestamp.class);
@@ -79,6 +79,8 @@ public class SCategory_ extends com.querydsl.sql.RelationalPathBase<SCategory_> 
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         categorydescription,
         ColumnMetadata.named("CATEGORYDESCRIPTION")
             .withIndex(2)
@@ -99,8 +101,6 @@ public class SCategory_ extends com.querydsl.sql.RelationalPathBase<SCategory_> 
     addMetadata(
         deletedby,
         ColumnMetadata.named("DELETEDBY").withIndex(7).ofType(Types.DOUBLE).withSize(22));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         modificationdate,
         ColumnMetadata.named("MODIFICATIONDATE").withIndex(8).ofType(Types.TIMESTAMP).withSize(19));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCategory_category_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCategory_category_.java
@@ -18,9 +18,9 @@ public class SCategory_category_ extends com.querydsl.sql.RelationalPathBase<SCa
   public static final SCategory_category_ category_category_ =
       new SCategory_category_("category__category_");
 
-  public final NumberPath<Long> childId = createNumber("childId", Long.class);
-
   public final NumberPath<Long> parentId = createNumber("parentId", Long.class);
+
+  public final NumberPath<Long> childId = createNumber("childId", Long.class);
 
   public final com.querydsl.sql.PrimaryKey<SCategory_category_> primary =
       createPrimaryKey(childId, parentId);
@@ -58,10 +58,10 @@ public class SCategory_category_ extends com.querydsl.sql.RelationalPathBase<SCa
 
   public void addMetadata() {
     addMetadata(
-        childId,
-        ColumnMetadata.named("childId").withIndex(2).ofType(Types.BIGINT).withSize(19).notNull());
-    addMetadata(
         parentId,
         ColumnMetadata.named("parentId").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
+        childId,
+        ColumnMetadata.named("childId").withIndex(2).ofType(Types.BIGINT).withSize(19).notNull());
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCategoryprop_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCategoryprop_.java
@@ -17,9 +17,9 @@ public class SCategoryprop_ extends com.querydsl.sql.RelationalPathBase<SCategor
 
   public static final SCategoryprop_ categoryprop_ = new SCategoryprop_("categoryprop_");
 
-  public final NumberPath<Long> categoryid = createNumber("categoryid", Long.class);
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
+
+  public final NumberPath<Long> categoryid = createNumber("categoryid", Long.class);
 
   public final StringPath propname = createString("propname");
 
@@ -60,10 +60,10 @@ public class SCategoryprop_ extends com.querydsl.sql.RelationalPathBase<SCategor
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         categoryid,
         ColumnMetadata.named("CATEGORYID").withIndex(2).ofType(Types.BIGINT).withSize(19));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         propname,
         ColumnMetadata.named("PROPNAME").withIndex(3).ofType(Types.VARCHAR).withSize(255));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCompany.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCompany.java
@@ -9,13 +9,13 @@ import com.querydsl.sql.ColumnMetadata;
 import java.sql.Types;
 import javax.annotation.processing.Generated;
 
-/** SCompany_ is a Querydsl query type for SCompany_ */
+/** SCompany is a Querydsl query type for SCompany */
 @Generated("com.querydsl.sql.codegen.MetaDataSerializer")
-public class SCompany_ extends com.querydsl.sql.RelationalPathBase<SCompany_> {
+public class SCompany extends com.querydsl.sql.RelationalPathBase<SCompany> {
 
-  private static final long serialVersionUID = -590751734;
+  private static final long serialVersionUID = -434698507;
 
-  public static final SCompany_ company_ = new SCompany_("company_");
+  public static final SCompany company = new SCompany("company");
 
   public final NumberPath<Integer> id = createNumber("id", Integer.class);
 
@@ -29,45 +29,36 @@ public class SCompany_ extends com.querydsl.sql.RelationalPathBase<SCompany_> {
 
   public final NumberPath<Integer> ceoId = createNumber("ceoId", Integer.class);
 
-  public final com.querydsl.sql.PrimaryKey<SCompany_> primary = createPrimaryKey(id);
+  public final com.querydsl.sql.PrimaryKey<SCompany> primary = createPrimaryKey(id);
 
-  public final com.querydsl.sql.ForeignKey<SEmployee_> company_CEOIDFK =
+  public final com.querydsl.sql.ForeignKey<SEmployee_> companyCEOIDFK =
       createForeignKey(ceoId, "ID");
 
-  public final com.querydsl.sql.ForeignKey<SCompany_department_> _company_department_CompanyIDFK =
+  public final com.querydsl.sql.ForeignKey<SCompanyDepartment_> _companyDepartment_CompanyIDFK =
       createInvForeignKey(id, "Company_ID");
 
-  public final com.querydsl.sql.ForeignKey<SDepartment_> _department_COMPANYIDFK =
-      createInvForeignKey(id, "COMPANY_ID");
-
-  public final com.querydsl.sql.ForeignKey<SEmployee_> _employee_COMPANYIDFK =
-      createInvForeignKey(id, "COMPANY_ID");
-
-  public final com.querydsl.sql.ForeignKey<SUser_> _user_COMPANYIDFK =
-      createInvForeignKey(id, "COMPANY_ID");
-
-  public SCompany_(String variable) {
-    super(SCompany_.class, forVariable(variable), "null", "company_");
+  public SCompany(String variable) {
+    super(SCompany.class, forVariable(variable), "null", "company");
     addMetadata();
   }
 
-  public SCompany_(String variable, String schema, String table) {
-    super(SCompany_.class, forVariable(variable), schema, table);
+  public SCompany(String variable, String schema, String table) {
+    super(SCompany.class, forVariable(variable), schema, table);
     addMetadata();
   }
 
-  public SCompany_(String variable, String schema) {
-    super(SCompany_.class, forVariable(variable), schema, "company_");
+  public SCompany(String variable, String schema) {
+    super(SCompany.class, forVariable(variable), schema, "company");
     addMetadata();
   }
 
-  public SCompany_(Path<? extends SCompany_> path) {
-    super(path.getType(), path.getMetadata(), "null", "company_");
+  public SCompany(Path<? extends SCompany> path) {
+    super(path.getType(), path.getMetadata(), "null", "company");
     addMetadata();
   }
 
-  public SCompany_(PathMetadata metadata) {
-    super(SCompany_.class, metadata, "null", "company_");
+  public SCompany(PathMetadata metadata) {
+    super(SCompany.class, metadata, "null", "company");
     addMetadata();
   }
 

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCompanyDepartment_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCompanyDepartment_.java
@@ -1,0 +1,75 @@
+package com.querydsl.jpa.domain.sql;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
+import com.querydsl.sql.ColumnMetadata;
+import java.sql.Types;
+import javax.annotation.processing.Generated;
+
+/** SCompanyDepartment_ is a Querydsl query type for SCompanyDepartment_ */
+@Generated("com.querydsl.sql.codegen.MetaDataSerializer")
+public class SCompanyDepartment_ extends com.querydsl.sql.RelationalPathBase<SCompanyDepartment_> {
+
+  private static final long serialVersionUID = 1058032920;
+
+  public static final SCompanyDepartment_ companyDepartment_ =
+      new SCompanyDepartment_("company_department_");
+
+  public final NumberPath<Integer> companyID = createNumber("companyID", Integer.class);
+
+  public final NumberPath<Integer> departmentsID = createNumber("departmentsID", Integer.class);
+
+  public final com.querydsl.sql.PrimaryKey<SCompanyDepartment_> primary =
+      createPrimaryKey(companyID, departmentsID);
+
+  public final com.querydsl.sql.ForeignKey<SCompany> companyDepartment_CompanyIDFK =
+      createForeignKey(companyID, "ID");
+
+  public final com.querydsl.sql.ForeignKey<SDepartment_> companyDepartment_departmentsIDFK =
+      createForeignKey(departmentsID, "ID");
+
+  public SCompanyDepartment_(String variable) {
+    super(SCompanyDepartment_.class, forVariable(variable), "null", "company_department_");
+    addMetadata();
+  }
+
+  public SCompanyDepartment_(String variable, String schema, String table) {
+    super(SCompanyDepartment_.class, forVariable(variable), schema, table);
+    addMetadata();
+  }
+
+  public SCompanyDepartment_(String variable, String schema) {
+    super(SCompanyDepartment_.class, forVariable(variable), schema, "company_department_");
+    addMetadata();
+  }
+
+  public SCompanyDepartment_(Path<? extends SCompanyDepartment_> path) {
+    super(path.getType(), path.getMetadata(), "null", "company_department_");
+    addMetadata();
+  }
+
+  public SCompanyDepartment_(PathMetadata metadata) {
+    super(SCompanyDepartment_.class, metadata, "null", "company_department_");
+    addMetadata();
+  }
+
+  public void addMetadata() {
+    addMetadata(
+        companyID,
+        ColumnMetadata.named("Company_ID")
+            .withIndex(1)
+            .ofType(Types.INTEGER)
+            .withSize(10)
+            .notNull());
+    addMetadata(
+        departmentsID,
+        ColumnMetadata.named("departments_ID")
+            .withIndex(2)
+            .ofType(Types.INTEGER)
+            .withSize(10)
+            .notNull());
+  }
+}

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCustomer_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SCustomer_.java
@@ -17,9 +17,9 @@ public class SCustomer_ extends com.querydsl.sql.RelationalPathBase<SCustomer_> 
 
   public static final SCustomer_ customer_ = new SCustomer_("customer_");
 
-  public final NumberPath<Long> currentorderId = createNumber("currentorderId", Long.class);
-
   public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
+  public final NumberPath<Long> currentorderId = createNumber("currentorderId", Long.class);
 
   public final NumberPath<Long> nameId = createNumber("nameId", Long.class);
 
@@ -64,10 +64,10 @@ public class SCustomer_ extends com.querydsl.sql.RelationalPathBase<SCustomer_> 
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
+    addMetadata(
         currentorderId,
         ColumnMetadata.named("CURRENTORDER_ID").withIndex(2).ofType(Types.BIGINT).withSize(19));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
     addMetadata(
         nameId, ColumnMetadata.named("NAME_ID").withIndex(3).ofType(Types.BIGINT).withSize(19));
   }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SDepartment_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SDepartment_.java
@@ -17,11 +17,11 @@ public class SDepartment_ extends com.querydsl.sql.RelationalPathBase<SDepartmen
 
   public static final SDepartment_ department_ = new SDepartment_("department_");
 
-  public final NumberPath<Integer> companyId = createNumber("companyId", Integer.class);
-
   public final NumberPath<Integer> id = createNumber("id", Integer.class);
 
   public final StringPath name = createString("name");
+
+  public final NumberPath<Integer> companyId = createNumber("companyId", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SDepartment_> primary = createPrimaryKey(id);
 
@@ -30,6 +30,9 @@ public class SDepartment_ extends com.querydsl.sql.RelationalPathBase<SDepartmen
 
   public final com.querydsl.sql.ForeignKey<SCompany_department_>
       _company_department_departmentsIDFK = createInvForeignKey(id, "departments_ID");
+
+  public final com.querydsl.sql.ForeignKey<SCompanyDepartment_> _companyDepartment_departmentsIDFK =
+      createInvForeignKey(id, "departments_ID");
 
   public final com.querydsl.sql.ForeignKey<SDepartment_employee_>
       _department_employee_DepartmentIDFK = createInvForeignKey(id, "Department_ID");
@@ -61,11 +64,11 @@ public class SDepartment_ extends com.querydsl.sql.RelationalPathBase<SDepartmen
 
   public void addMetadata() {
     addMetadata(
-        companyId,
-        ColumnMetadata.named("COMPANY_ID").withIndex(3).ofType(Types.INTEGER).withSize(10));
-    addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
     addMetadata(
         name, ColumnMetadata.named("NAME").withIndex(2).ofType(Types.VARCHAR).withSize(255));
+    addMetadata(
+        companyId,
+        ColumnMetadata.named("COMPANY_ID").withIndex(3).ofType(Types.INTEGER).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SDocument2_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SDocument2_.java
@@ -17,6 +17,8 @@ public class SDocument2_ extends com.querydsl.sql.RelationalPathBase<SDocument2_
 
   public static final SDocument2_ document2_ = new SDocument2_("document2_");
 
+  public final NumberPath<Long> id = createNumber("id", Long.class);
+
   public final NumberPath<Double> createdby = createNumber("createdby", Double.class);
 
   public final DateTimePath<java.sql.Timestamp> creationdate =
@@ -38,8 +40,6 @@ public class SDocument2_ extends com.querydsl.sql.RelationalPathBase<SDocument2_
   public final NumberPath<Double> documentversion = createNumber("documentversion", Double.class);
 
   public final NumberPath<Double> entryid = createNumber("entryid", Double.class);
-
-  public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final DateTimePath<java.sql.Timestamp> modificationdate =
       createDateTime("modificationdate", java.sql.Timestamp.class);
@@ -75,6 +75,8 @@ public class SDocument2_ extends com.querydsl.sql.RelationalPathBase<SDocument2_
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         createdby,
         ColumnMetadata.named("CREATEDBY").withIndex(2).ofType(Types.DOUBLE).withSize(22));
     addMetadata(
@@ -103,8 +105,6 @@ public class SDocument2_ extends com.querydsl.sql.RelationalPathBase<SDocument2_
         ColumnMetadata.named("DOCUMENTVERSION").withIndex(10).ofType(Types.DOUBLE).withSize(22));
     addMetadata(
         entryid, ColumnMetadata.named("ENTRYID").withIndex(11).ofType(Types.DOUBLE).withSize(22));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         modificationdate,
         ColumnMetadata.named("MODIFICATIONDATE")

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SDocumentprop_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SDocumentprop_.java
@@ -17,9 +17,9 @@ public class SDocumentprop_ extends com.querydsl.sql.RelationalPathBase<SDocumen
 
   public static final SDocumentprop_ documentprop_ = new SDocumentprop_("documentprop_");
 
-  public final NumberPath<Double> documentid = createNumber("documentid", Double.class);
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
+
+  public final NumberPath<Double> documentid = createNumber("documentid", Double.class);
 
   public final StringPath propname = createString("propname");
 
@@ -56,10 +56,10 @@ public class SDocumentprop_ extends com.querydsl.sql.RelationalPathBase<SDocumen
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         documentid,
         ColumnMetadata.named("DOCUMENTID").withIndex(2).ofType(Types.DOUBLE).withSize(22));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         propname,
         ColumnMetadata.named("PROPNAME").withIndex(3).ofType(Types.VARCHAR).withSize(255));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SEmployee.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SEmployee.java
@@ -17,19 +17,19 @@ public class SEmployee extends com.querydsl.sql.RelationalPathBase<SEmployee> {
 
   public static final SEmployee employee = new SEmployee("EMPLOYEE");
 
-  public final DatePath<java.sql.Date> datefield = createDate("datefield", java.sql.Date.class);
+  public final NumberPath<Integer> id = createNumber("id", Integer.class);
 
   public final StringPath firstname = createString("firstname");
-
-  public final NumberPath<Integer> id = createNumber("id", Integer.class);
 
   public final StringPath lastname = createString("lastname");
 
   public final NumberPath<Long> salary = createNumber("salary", Long.class);
 
-  public final NumberPath<Integer> superiorId = createNumber("superiorId", Integer.class);
+  public final DatePath<java.sql.Date> datefield = createDate("datefield", java.sql.Date.class);
 
   public final TimePath<java.sql.Time> timefield = createTime("timefield", java.sql.Time.class);
+
+  public final NumberPath<Integer> superiorId = createNumber("superiorId", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SEmployee> primary = createPrimaryKey(id);
 
@@ -66,20 +66,20 @@ public class SEmployee extends com.querydsl.sql.RelationalPathBase<SEmployee> {
 
   public void addMetadata() {
     addMetadata(
-        datefield, ColumnMetadata.named("DATEFIELD").withIndex(5).ofType(Types.DATE).withSize(10));
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
     addMetadata(
         firstname,
         ColumnMetadata.named("FIRSTNAME").withIndex(2).ofType(Types.VARCHAR).withSize(50));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
     addMetadata(
         lastname, ColumnMetadata.named("LASTNAME").withIndex(3).ofType(Types.VARCHAR).withSize(50));
     addMetadata(
         salary, ColumnMetadata.named("SALARY").withIndex(4).ofType(Types.DECIMAL).withSize(10));
     addMetadata(
-        superiorId,
-        ColumnMetadata.named("SUPERIOR_ID").withIndex(7).ofType(Types.INTEGER).withSize(10));
+        datefield, ColumnMetadata.named("DATEFIELD").withIndex(5).ofType(Types.DATE).withSize(10));
     addMetadata(
         timefield, ColumnMetadata.named("TIMEFIELD").withIndex(6).ofType(Types.TIME).withSize(8));
+    addMetadata(
+        superiorId,
+        ColumnMetadata.named("SUPERIOR_ID").withIndex(7).ofType(Types.INTEGER).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SEmployee_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SEmployee_.java
@@ -17,13 +17,13 @@ public class SEmployee_ extends com.querydsl.sql.RelationalPathBase<SEmployee_> 
 
   public static final SEmployee_ employee_ = new SEmployee_("employee_");
 
-  public final NumberPath<Integer> companyId = createNumber("companyId", Integer.class);
+  public final NumberPath<Integer> id = createNumber("id", Integer.class);
 
   public final StringPath firstname = createString("firstname");
 
-  public final NumberPath<Integer> id = createNumber("id", Integer.class);
-
   public final StringPath lastname = createString("lastname");
+
+  public final NumberPath<Integer> companyId = createNumber("companyId", Integer.class);
 
   public final NumberPath<Long> userId = createNumber("userId", Long.class);
 
@@ -37,6 +37,9 @@ public class SEmployee_ extends com.querydsl.sql.RelationalPathBase<SEmployee_> 
 
   public final com.querydsl.sql.ForeignKey<SEmployeeJOBFUNCTIONS>
       _employeeJOBFUNCTIONSEmployeeIDFK = createInvForeignKey(id, "Employee_ID");
+
+  public final com.querydsl.sql.ForeignKey<SCompany> _companyCEOIDFK =
+      createInvForeignKey(id, "CEO_ID");
 
   public final com.querydsl.sql.ForeignKey<SCompany_> _company_CEOIDFK =
       createInvForeignKey(id, "CEO_ID");
@@ -71,16 +74,16 @@ public class SEmployee_ extends com.querydsl.sql.RelationalPathBase<SEmployee_> 
 
   public void addMetadata() {
     addMetadata(
-        companyId,
-        ColumnMetadata.named("COMPANY_ID").withIndex(4).ofType(Types.INTEGER).withSize(10));
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
     addMetadata(
         firstname,
         ColumnMetadata.named("FIRSTNAME").withIndex(2).ofType(Types.VARCHAR).withSize(255));
     addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
-    addMetadata(
         lastname,
         ColumnMetadata.named("LASTNAME").withIndex(3).ofType(Types.VARCHAR).withSize(255));
+    addMetadata(
+        companyId,
+        ColumnMetadata.named("COMPANY_ID").withIndex(4).ofType(Types.INTEGER).withSize(10));
     addMetadata(
         userId, ColumnMetadata.named("USER_ID").withIndex(5).ofType(Types.BIGINT).withSize(19));
   }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SEntity1.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SEntity1.java
@@ -17,9 +17,9 @@ public class SEntity1 extends com.querydsl.sql.RelationalPathBase<SEntity1> {
 
   public static final SEntity1 entity1 = new SEntity1("ENTITY1");
 
-  public final StringPath dtype = createString("dtype");
-
   public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
+  public final StringPath dtype = createString("dtype");
 
   public final StringPath property = createString("property");
 
@@ -54,9 +54,9 @@ public class SEntity1 extends com.querydsl.sql.RelationalPathBase<SEntity1> {
 
   public void addMetadata() {
     addMetadata(
-        dtype, ColumnMetadata.named("DTYPE").withIndex(2).ofType(Types.VARCHAR).withSize(31));
-    addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
+    addMetadata(
+        dtype, ColumnMetadata.named("DTYPE").withIndex(2).ofType(Types.VARCHAR).withSize(31));
     addMetadata(
         property,
         ColumnMetadata.named("PROPERTY").withIndex(3).ofType(Types.VARCHAR).withSize(255));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SEviltype_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SEviltype_.java
@@ -17,13 +17,15 @@ public class SEviltype_ extends com.querydsl.sql.RelationalPathBase<SEviltype_> 
 
   public static final SEviltype_ eviltype_ = new SEviltype_("eviltype_");
 
+  public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
   public final NumberPath<Integer> _asc = createNumber("_asc", Integer.class);
 
   public final NumberPath<Integer> _desc = createNumber("_desc", Integer.class);
 
-  public final NumberPath<Integer> getclassId = createNumber("getclassId", Integer.class);
-
   public final NumberPath<Integer> getId = createNumber("getId", Integer.class);
+
+  public final NumberPath<Integer> getclassId = createNumber("getclassId", Integer.class);
 
   public final NumberPath<Integer> getmetadataId = createNumber("getmetadataId", Integer.class);
 
@@ -31,15 +33,13 @@ public class SEviltype_ extends com.querydsl.sql.RelationalPathBase<SEviltype_> 
 
   public final NumberPath<Integer> hashcodeId = createNumber("hashcodeId", Integer.class);
 
-  public final NumberPath<Integer> id = createNumber("id", Integer.class);
-
   public final NumberPath<Integer> isnotnullId = createNumber("isnotnullId", Integer.class);
 
   public final NumberPath<Integer> isnullId = createNumber("isnullId", Integer.class);
 
-  public final NumberPath<Integer> notifyallId = createNumber("notifyallId", Integer.class);
-
   public final NumberPath<Integer> notifyId = createNumber("notifyId", Integer.class);
+
+  public final NumberPath<Integer> notifyallId = createNumber("notifyallId", Integer.class);
 
   public final NumberPath<Integer> tostringId = createNumber("tostringId", Integer.class);
 
@@ -151,14 +151,16 @@ public class SEviltype_ extends com.querydsl.sql.RelationalPathBase<SEviltype_> 
   }
 
   public void addMetadata() {
+    addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
     addMetadata(_asc, ColumnMetadata.named("_asc").withIndex(2).ofType(Types.INTEGER).withSize(10));
     addMetadata(
         _desc, ColumnMetadata.named("_desc").withIndex(3).ofType(Types.INTEGER).withSize(10));
     addMetadata(
+        getId, ColumnMetadata.named("GET_ID").withIndex(4).ofType(Types.INTEGER).withSize(10));
+    addMetadata(
         getclassId,
         ColumnMetadata.named("GETCLASS_ID").withIndex(5).ofType(Types.INTEGER).withSize(10));
-    addMetadata(
-        getId, ColumnMetadata.named("GET_ID").withIndex(4).ofType(Types.INTEGER).withSize(10));
     addMetadata(
         getmetadataId,
         ColumnMetadata.named("GETMETADATA_ID").withIndex(6).ofType(Types.INTEGER).withSize(10));
@@ -169,19 +171,17 @@ public class SEviltype_ extends com.querydsl.sql.RelationalPathBase<SEviltype_> 
         hashcodeId,
         ColumnMetadata.named("HASHCODE_ID").withIndex(8).ofType(Types.INTEGER).withSize(10));
     addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
-    addMetadata(
         isnotnullId,
         ColumnMetadata.named("ISNOTNULL_ID").withIndex(9).ofType(Types.INTEGER).withSize(10));
     addMetadata(
         isnullId,
         ColumnMetadata.named("ISNULL_ID").withIndex(10).ofType(Types.INTEGER).withSize(10));
     addMetadata(
-        notifyallId,
-        ColumnMetadata.named("NOTIFYALL_ID").withIndex(12).ofType(Types.INTEGER).withSize(10));
-    addMetadata(
         notifyId,
         ColumnMetadata.named("NOTIFY_ID").withIndex(11).ofType(Types.INTEGER).withSize(10));
+    addMetadata(
+        notifyallId,
+        ColumnMetadata.named("NOTIFYALL_ID").withIndex(12).ofType(Types.INTEGER).withSize(10));
     addMetadata(
         tostringId,
         ColumnMetadata.named("TOSTRING_ID").withIndex(13).ofType(Types.INTEGER).withSize(10));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SFoo_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SFoo_.java
@@ -17,9 +17,9 @@ public class SFoo_ extends com.querydsl.sql.RelationalPathBase<SFoo_> {
 
   public static final SFoo_ foo_ = new SFoo_("foo_");
 
-  public final StringPath bar = createString("bar");
-
   public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
+  public final StringPath bar = createString("bar");
 
   public final DatePath<java.sql.Date> startdate = createDate("startdate", java.sql.Date.class);
 
@@ -54,9 +54,9 @@ public class SFoo_ extends com.querydsl.sql.RelationalPathBase<SFoo_> {
   }
 
   public void addMetadata() {
-    addMetadata(bar, ColumnMetadata.named("BAR").withIndex(2).ofType(Types.VARCHAR).withSize(255));
     addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
+    addMetadata(bar, ColumnMetadata.named("BAR").withIndex(2).ofType(Types.VARCHAR).withSize(255));
     addMetadata(
         startdate, ColumnMetadata.named("STARTDATE").withIndex(3).ofType(Types.DATE).withSize(10));
   }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SHumanHAIRS.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SHumanHAIRS.java
@@ -17,9 +17,9 @@ public class SHumanHAIRS extends com.querydsl.sql.RelationalPathBase<SHumanHAIRS
 
   public static final SHumanHAIRS HumanHAIRS = new SHumanHAIRS("Human_HAIRS");
 
-  public final NumberPath<Integer> hairs = createNumber("hairs", Integer.class);
-
   public final NumberPath<Long> humanID = createNumber("humanID", Long.class);
+
+  public final NumberPath<Integer> hairs = createNumber("hairs", Integer.class);
 
   public final com.querydsl.sql.ForeignKey<SMammal> humanHAIRSHumanIDFK =
       createForeignKey(humanID, "ID");
@@ -51,8 +51,8 @@ public class SHumanHAIRS extends com.querydsl.sql.RelationalPathBase<SHumanHAIRS
 
   public void addMetadata() {
     addMetadata(
-        hairs, ColumnMetadata.named("HAIRS").withIndex(2).ofType(Types.INTEGER).withSize(10));
-    addMetadata(
         humanID, ColumnMetadata.named("Human_ID").withIndex(1).ofType(Types.BIGINT).withSize(19));
+    addMetadata(
+        hairs, ColumnMetadata.named("HAIRS").withIndex(2).ofType(Types.INTEGER).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SInheritedproperties_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SInheritedproperties_.java
@@ -19,9 +19,9 @@ public class SInheritedproperties_
   public static final SInheritedproperties_ inheritedproperties_ =
       new SInheritedproperties_("inheritedproperties_");
 
-  public final StringPath classproperty = createString("classproperty");
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
+
+  public final StringPath classproperty = createString("classproperty");
 
   public final StringPath stringassimple = createString("stringassimple");
 
@@ -56,10 +56,10 @@ public class SInheritedproperties_
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         classproperty,
         ColumnMetadata.named("CLASSPROPERTY").withIndex(2).ofType(Types.VARCHAR).withSize(255));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         stringassimple,
         ColumnMetadata.named("STRINGASSIMPLE").withIndex(3).ofType(Types.VARCHAR).withSize(255));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SItem_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SItem_.java
@@ -17,17 +17,17 @@ public class SItem_ extends com.querydsl.sql.RelationalPathBase<SItem_> {
 
   public static final SItem_ item_ = new SItem_("item_");
 
-  public final NumberPath<Long> currentstatusId = createNumber("currentstatusId", Long.class);
+  public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final StringPath dtype = createString("dtype");
 
-  public final NumberPath<Long> id = createNumber("id", Long.class);
+  public final NumberPath<Long> productId = createNumber("productId", Long.class);
 
   public final StringPath name = createString("name");
 
   public final NumberPath<Integer> paymentstatus = createNumber("paymentstatus", Integer.class);
 
-  public final NumberPath<Long> productId = createNumber("productId", Long.class);
+  public final NumberPath<Long> currentstatusId = createNumber("currentstatusId", Long.class);
 
   public final NumberPath<Long> statusId = createNumber("statusId", Long.class);
 
@@ -90,20 +90,20 @@ public class SItem_ extends com.querydsl.sql.RelationalPathBase<SItem_> {
 
   public void addMetadata() {
     addMetadata(
-        currentstatusId,
-        ColumnMetadata.named("CURRENTSTATUS_ID").withIndex(6).ofType(Types.BIGINT).withSize(19));
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         dtype, ColumnMetadata.named("DTYPE").withIndex(2).ofType(Types.VARCHAR).withSize(31));
     addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+        productId,
+        ColumnMetadata.named("PRODUCT_ID").withIndex(3).ofType(Types.BIGINT).withSize(19));
     addMetadata(
         name, ColumnMetadata.named("NAME").withIndex(4).ofType(Types.VARCHAR).withSize(255));
     addMetadata(
         paymentstatus,
         ColumnMetadata.named("PAYMENTSTATUS").withIndex(5).ofType(Types.INTEGER).withSize(10));
     addMetadata(
-        productId,
-        ColumnMetadata.named("PRODUCT_ID").withIndex(3).ofType(Types.BIGINT).withSize(19));
+        currentstatusId,
+        ColumnMetadata.named("CURRENTSTATUS_ID").withIndex(6).ofType(Types.BIGINT).withSize(19));
     addMetadata(
         statusId, ColumnMetadata.named("STATUS_ID").withIndex(7).ofType(Types.BIGINT).withSize(19));
   }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SKittens.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SKittens.java
@@ -19,9 +19,9 @@ public class SKittens extends com.querydsl.sql.RelationalPathBase<SKittens> {
 
   public final NumberPath<Integer> catId = createNumber("catId", Integer.class);
 
-  public final NumberPath<Integer> ind = createNumber("ind", Integer.class);
-
   public final NumberPath<Integer> kittenId = createNumber("kittenId", Integer.class);
+
+  public final NumberPath<Integer> ind = createNumber("ind", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SKittens> primary = createPrimaryKey(catId, kittenId);
 
@@ -59,7 +59,6 @@ public class SKittens extends com.querydsl.sql.RelationalPathBase<SKittens> {
     addMetadata(
         catId,
         ColumnMetadata.named("cat_id").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
-    addMetadata(ind, ColumnMetadata.named("ind").withIndex(3).ofType(Types.INTEGER).withSize(10));
     addMetadata(
         kittenId,
         ColumnMetadata.named("kitten_id")
@@ -67,5 +66,6 @@ public class SKittens extends com.querydsl.sql.RelationalPathBase<SKittens> {
             .ofType(Types.INTEGER)
             .withSize(10)
             .notNull());
+    addMetadata(ind, ColumnMetadata.named("ind").withIndex(3).ofType(Types.INTEGER).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SLineItems.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SLineItems.java
@@ -17,11 +17,11 @@ public class SLineItems extends com.querydsl.sql.RelationalPathBase<SLineItems> 
 
   public static final SLineItems LineItems = new SLineItems("LineItems");
 
-  public final NumberPath<Integer> _index = createNumber("_index", Integer.class);
+  public final NumberPath<Long> orderID = createNumber("orderID", Long.class);
 
   public final NumberPath<Long> lineItemsID = createNumber("lineItemsID", Long.class);
 
-  public final NumberPath<Long> orderID = createNumber("orderID", Long.class);
+  public final NumberPath<Integer> _index = createNumber("_index", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SLineItems> primary =
       createPrimaryKey(orderID, lineItemsID);
@@ -59,7 +59,8 @@ public class SLineItems extends com.querydsl.sql.RelationalPathBase<SLineItems> 
 
   public void addMetadata() {
     addMetadata(
-        _index, ColumnMetadata.named("_index").withIndex(3).ofType(Types.INTEGER).withSize(10));
+        orderID,
+        ColumnMetadata.named("Order_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         lineItemsID,
         ColumnMetadata.named("lineItems_ID")
@@ -68,7 +69,6 @@ public class SLineItems extends com.querydsl.sql.RelationalPathBase<SLineItems> 
             .withSize(19)
             .notNull());
     addMetadata(
-        orderID,
-        ColumnMetadata.named("Order_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+        _index, ColumnMetadata.named("_index").withIndex(3).ofType(Types.INTEGER).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SLineItems2.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SLineItems2.java
@@ -17,9 +17,9 @@ public class SLineItems2 extends com.querydsl.sql.RelationalPathBase<SLineItems2
 
   public static final SLineItems2 LineItems2 = new SLineItems2("LineItems2");
 
-  public final NumberPath<Long> lineItemsMapID = createNumber("lineItemsMapID", Long.class);
-
   public final NumberPath<Long> orderID = createNumber("orderID", Long.class);
+
+  public final NumberPath<Long> lineItemsMapID = createNumber("lineItemsMapID", Long.class);
 
   public final com.querydsl.sql.PrimaryKey<SLineItems2> primary =
       createPrimaryKey(orderID, lineItemsMapID);
@@ -57,14 +57,14 @@ public class SLineItems2 extends com.querydsl.sql.RelationalPathBase<SLineItems2
 
   public void addMetadata() {
     addMetadata(
+        orderID,
+        ColumnMetadata.named("Order_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         lineItemsMapID,
         ColumnMetadata.named("lineItemsMap_ID")
             .withIndex(2)
             .ofType(Types.BIGINT)
             .withSize(19)
             .notNull());
-    addMetadata(
-        orderID,
-        ColumnMetadata.named("Order_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SMammal.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SMammal.java
@@ -17,9 +17,9 @@ public class SMammal extends com.querydsl.sql.RelationalPathBase<SMammal> {
 
   public static final SMammal mammal = new SMammal("MAMMAL");
 
-  public final StringPath dtype = createString("dtype");
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
+
+  public final StringPath dtype = createString("dtype");
 
   public final com.querydsl.sql.PrimaryKey<SMammal> primary = createPrimaryKey(id);
 
@@ -56,8 +56,8 @@ public class SMammal extends com.querydsl.sql.RelationalPathBase<SMammal> {
 
   public void addMetadata() {
     addMetadata(
-        dtype, ColumnMetadata.named("DTYPE").withIndex(2).ofType(Types.VARCHAR).withSize(31));
-    addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
+        dtype, ColumnMetadata.named("DTYPE").withIndex(2).ofType(Types.VARCHAR).withSize(31));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SMyentity.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SMyentity.java
@@ -17,10 +17,10 @@ public class SMyentity extends com.querydsl.sql.RelationalPathBase<SMyentity> {
 
   public static final SMyentity myentity = new SMyentity("MYENTITY");
 
+  public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
   public final NumberPath<Integer> attributewithinitproblemId =
       createNumber("attributewithinitproblemId", Integer.class);
-
-  public final NumberPath<Integer> id = createNumber("id", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SMyentity> primary = createPrimaryKey(id);
 
@@ -54,12 +54,12 @@ public class SMyentity extends com.querydsl.sql.RelationalPathBase<SMyentity> {
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
+    addMetadata(
         attributewithinitproblemId,
         ColumnMetadata.named("ATTRIBUTEWITHINITPROBLEM_ID")
             .withIndex(2)
             .ofType(Types.INTEGER)
             .withSize(10));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SName_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SName_.java
@@ -17,9 +17,9 @@ public class SName_ extends com.querydsl.sql.RelationalPathBase<SName_> {
 
   public static final SName_ name_ = new SName_("name_");
 
-  public final StringPath firstname = createString("firstname");
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
+
+  public final StringPath firstname = createString("firstname");
 
   public final StringPath lastname = createString("lastname");
 
@@ -57,10 +57,10 @@ public class SName_ extends com.querydsl.sql.RelationalPathBase<SName_> {
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         firstname,
         ColumnMetadata.named("FIRSTNAME").withIndex(2).ofType(Types.VARCHAR).withSize(255));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         lastname,
         ColumnMetadata.named("LASTNAME").withIndex(3).ofType(Types.VARCHAR).withSize(255));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SNationality_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SNationality_.java
@@ -17,9 +17,9 @@ public class SNationality_ extends com.querydsl.sql.RelationalPathBase<SNational
 
   public static final SNationality_ nationality_ = new SNationality_("nationality_");
 
-  public final NumberPath<Integer> calendarId = createNumber("calendarId", Integer.class);
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
+
+  public final NumberPath<Integer> calendarId = createNumber("calendarId", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SNationality_> primary = createPrimaryKey(id);
 
@@ -56,9 +56,9 @@ public class SNationality_ extends com.querydsl.sql.RelationalPathBase<SNational
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         calendarId,
         ColumnMetadata.named("CALENDAR_ID").withIndex(2).ofType(Types.INTEGER).withSize(10));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SOrderDELIVEREDITEMINDICES.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SOrderDELIVEREDITEMINDICES.java
@@ -19,12 +19,12 @@ public class SOrderDELIVEREDITEMINDICES
   public static final SOrderDELIVEREDITEMINDICES OrderDELIVEREDITEMINDICES =
       new SOrderDELIVEREDITEMINDICES("Order_DELIVEREDITEMINDICES");
 
-  public final NumberPath<Integer> _index = createNumber("_index", Integer.class);
+  public final NumberPath<Long> orderID = createNumber("orderID", Long.class);
 
   public final NumberPath<Integer> delivereditemindices =
       createNumber("delivereditemindices", Integer.class);
 
-  public final NumberPath<Long> orderID = createNumber("orderID", Long.class);
+  public final NumberPath<Integer> _index = createNumber("_index", Integer.class);
 
   public final com.querydsl.sql.ForeignKey<SOrder_> orderDELIVEREDITEMINDICESOrderIDFK =
       createForeignKey(orderID, "ID");
@@ -64,7 +64,7 @@ public class SOrderDELIVEREDITEMINDICES
 
   public void addMetadata() {
     addMetadata(
-        _index, ColumnMetadata.named("_index").withIndex(3).ofType(Types.INTEGER).withSize(10));
+        orderID, ColumnMetadata.named("Order_ID").withIndex(1).ofType(Types.BIGINT).withSize(19));
     addMetadata(
         delivereditemindices,
         ColumnMetadata.named("DELIVEREDITEMINDICES")
@@ -72,6 +72,6 @@ public class SOrderDELIVEREDITEMINDICES
             .ofType(Types.INTEGER)
             .withSize(10));
     addMetadata(
-        orderID, ColumnMetadata.named("Order_ID").withIndex(1).ofType(Types.BIGINT).withSize(19));
+        _index, ColumnMetadata.named("_index").withIndex(3).ofType(Types.INTEGER).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SOrder_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SOrder_.java
@@ -17,11 +17,11 @@ public class SOrder_ extends com.querydsl.sql.RelationalPathBase<SOrder_> {
 
   public static final SOrder_ order_ = new SOrder_("order_");
 
-  public final NumberPath<Integer> customerId = createNumber("customerId", Integer.class);
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final BooleanPath paid = createBoolean("paid");
+
+  public final NumberPath<Integer> customerId = createNumber("customerId", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SOrder_> primary = createPrimaryKey(id);
 
@@ -70,10 +70,10 @@ public class SOrder_ extends com.querydsl.sql.RelationalPathBase<SOrder_> {
 
   public void addMetadata() {
     addMetadata(
-        customerId,
-        ColumnMetadata.named("CUSTOMER_ID").withIndex(3).ofType(Types.INTEGER).withSize(10));
-    addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(paid, ColumnMetadata.named("PAID").withIndex(2).ofType(Types.BIT).withSize(1));
+    addMetadata(
+        customerId,
+        ColumnMetadata.named("CUSTOMER_ID").withIndex(3).ofType(Types.INTEGER).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SOrder_item_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SOrder_item_.java
@@ -17,11 +17,11 @@ public class SOrder_item_ extends com.querydsl.sql.RelationalPathBase<SOrder_ite
 
   public static final SOrder_item_ order_item_ = new SOrder_item_("order__item_");
 
-  public final NumberPath<Integer> _index = createNumber("_index", Integer.class);
+  public final NumberPath<Long> orderID = createNumber("orderID", Long.class);
 
   public final NumberPath<Long> itemsID = createNumber("itemsID", Long.class);
 
-  public final NumberPath<Long> orderID = createNumber("orderID", Long.class);
+  public final NumberPath<Integer> _index = createNumber("_index", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SOrder_item_> primary =
       createPrimaryKey(orderID, itemsID);
@@ -59,12 +59,12 @@ public class SOrder_item_ extends com.querydsl.sql.RelationalPathBase<SOrder_ite
 
   public void addMetadata() {
     addMetadata(
-        _index, ColumnMetadata.named("_index").withIndex(3).ofType(Types.INTEGER).withSize(10));
+        orderID,
+        ColumnMetadata.named("Order_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         itemsID,
         ColumnMetadata.named("items_ID").withIndex(2).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
-        orderID,
-        ColumnMetadata.named("Order_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+        _index, ColumnMetadata.named("_index").withIndex(3).ofType(Types.INTEGER).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SParent_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SParent_.java
@@ -17,11 +17,11 @@ public class SParent_ extends com.querydsl.sql.RelationalPathBase<SParent_> {
 
   public static final SParent_ parent_ = new SParent_("parent_");
 
-  public final StringPath childname = createString("childname");
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final StringPath name = createString("name");
+
+  public final StringPath childname = createString("childname");
 
   public final com.querydsl.sql.PrimaryKey<SParent_> primary = createPrimaryKey(id);
 
@@ -52,11 +52,11 @@ public class SParent_ extends com.querydsl.sql.RelationalPathBase<SParent_> {
 
   public void addMetadata() {
     addMetadata(
-        childname,
-        ColumnMetadata.named("CHILDNAME").withIndex(3).ofType(Types.VARCHAR).withSize(255));
-    addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         name, ColumnMetadata.named("NAME").withIndex(2).ofType(Types.VARCHAR).withSize(255));
+    addMetadata(
+        childname,
+        ColumnMetadata.named("CHILDNAME").withIndex(3).ofType(Types.VARCHAR).withSize(255));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SPerson_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SPerson_.java
@@ -17,9 +17,9 @@ public class SPerson_ extends com.querydsl.sql.RelationalPathBase<SPerson_> {
 
   public static final SPerson_ person_ = new SPerson_("person_");
 
-  public final DatePath<java.sql.Date> birthday = createDate("birthday", java.sql.Date.class);
-
   public final NumberPath<Long> i = createNumber("i", Long.class);
+
+  public final DatePath<java.sql.Date> birthday = createDate("birthday", java.sql.Date.class);
 
   public final StringPath name = createString("name");
 
@@ -65,9 +65,9 @@ public class SPerson_ extends com.querydsl.sql.RelationalPathBase<SPerson_> {
 
   public void addMetadata() {
     addMetadata(
-        birthday, ColumnMetadata.named("BIRTHDAY").withIndex(2).ofType(Types.DATE).withSize(10));
-    addMetadata(
         i, ColumnMetadata.named("I").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
+        birthday, ColumnMetadata.named("BIRTHDAY").withIndex(2).ofType(Types.DATE).withSize(10));
     addMetadata(
         name, ColumnMetadata.named("NAME").withIndex(3).ofType(Types.VARCHAR).withSize(255));
     addMetadata(

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SPersonid_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SPersonid_.java
@@ -17,9 +17,9 @@ public class SPersonid_ extends com.querydsl.sql.RelationalPathBase<SPersonid_> 
 
   public static final SPersonid_ personid_ = new SPersonid_("personid_");
 
-  public final StringPath country = createString("country");
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
+
+  public final StringPath country = createString("country");
 
   public final NumberPath<Integer> medicarenumber = createNumber("medicarenumber", Integer.class);
 
@@ -55,9 +55,9 @@ public class SPersonid_ extends com.querydsl.sql.RelationalPathBase<SPersonid_> 
 
   public void addMetadata() {
     addMetadata(
-        country, ColumnMetadata.named("COUNTRY").withIndex(2).ofType(Types.VARCHAR).withSize(255));
-    addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
+        country, ColumnMetadata.named("COUNTRY").withIndex(2).ofType(Types.VARCHAR).withSize(255));
     addMetadata(
         medicarenumber,
         ColumnMetadata.named("MEDICARENUMBER").withIndex(3).ofType(Types.INTEGER).withSize(10));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SPrice_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SPrice_.java
@@ -17,9 +17,9 @@ public class SPrice_ extends com.querydsl.sql.RelationalPathBase<SPrice_> {
 
   public static final SPrice_ price_ = new SPrice_("price_");
 
-  public final NumberPath<Long> amount = createNumber("amount", Long.class);
-
   public final NumberPath<Long> id = createNumber("id", Long.class);
+
+  public final NumberPath<Long> amount = createNumber("amount", Long.class);
 
   public final NumberPath<Long> productId = createNumber("productId", Long.class);
 
@@ -58,9 +58,9 @@ public class SPrice_ extends com.querydsl.sql.RelationalPathBase<SPrice_> {
 
   public void addMetadata() {
     addMetadata(
-        amount, ColumnMetadata.named("AMOUNT").withIndex(2).ofType(Types.BIGINT).withSize(19));
-    addMetadata(
         id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
+        amount, ColumnMetadata.named("AMOUNT").withIndex(2).ofType(Types.BIGINT).withSize(19));
     addMetadata(
         productId,
         ColumnMetadata.named("PRODUCT_ID").withIndex(3).ofType(Types.BIGINT).withSize(19));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SSequence.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SSequence.java
@@ -17,10 +17,10 @@ public class SSequence extends com.querydsl.sql.RelationalPathBase<SSequence> {
 
   public static final SSequence sequence = new SSequence("SEQUENCE");
 
+  public final StringPath seqName = createString("seqName");
+
   public final NumberPath<java.math.BigInteger> seqCount =
       createNumber("seqCount", java.math.BigInteger.class);
-
-  public final StringPath seqName = createString("seqName");
 
   public final com.querydsl.sql.PrimaryKey<SSequence> primary = createPrimaryKey(seqName);
 
@@ -51,10 +51,10 @@ public class SSequence extends com.querydsl.sql.RelationalPathBase<SSequence> {
 
   public void addMetadata() {
     addMetadata(
-        seqCount,
-        ColumnMetadata.named("SEQ_COUNT").withIndex(2).ofType(Types.DECIMAL).withSize(38));
-    addMetadata(
         seqName,
         ColumnMetadata.named("SEQ_NAME").withIndex(1).ofType(Types.VARCHAR).withSize(50).notNull());
+    addMetadata(
+        seqCount,
+        ColumnMetadata.named("SEQ_COUNT").withIndex(2).ofType(Types.DECIMAL).withSize(38));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SShapes.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SShapes.java
@@ -17,9 +17,9 @@ public class SShapes extends com.querydsl.sql.RelationalPathBase<SShapes> {
 
   public static final SShapes shapes = new SShapes("SHAPES");
 
-  public final SimplePath<byte[]> geometry = createSimple("geometry", byte[].class);
-
   public final NumberPath<Integer> id = createNumber("id", Integer.class);
+
+  public final SimplePath<byte[]> geometry = createSimple("geometry", byte[].class);
 
   public final com.querydsl.sql.PrimaryKey<SShapes> primary = createPrimaryKey(id);
 
@@ -50,9 +50,9 @@ public class SShapes extends com.querydsl.sql.RelationalPathBase<SShapes> {
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
+    addMetadata(
         geometry,
         ColumnMetadata.named("GEOMETRY").withIndex(2).ofType(Types.BINARY).withSize(65535));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.INTEGER).withSize(10).notNull());
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SShowACTS.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SShowACTS.java
@@ -17,11 +17,11 @@ public class SShowACTS extends com.querydsl.sql.RelationalPathBase<SShowACTS> {
 
   public static final SShowACTS ShowACTS = new SShowACTS("Show_ACTS");
 
+  public final NumberPath<Long> showID = createNumber("showID", Long.class);
+
   public final StringPath acts = createString("acts");
 
   public final StringPath actsKey = createString("actsKey");
-
-  public final NumberPath<Long> showID = createNumber("showID", Long.class);
 
   public final com.querydsl.sql.ForeignKey<SShow_> showACTSShowIDFK =
       createForeignKey(showID, "ID");
@@ -53,10 +53,10 @@ public class SShowACTS extends com.querydsl.sql.RelationalPathBase<SShowACTS> {
 
   public void addMetadata() {
     addMetadata(
+        showID, ColumnMetadata.named("Show_ID").withIndex(1).ofType(Types.BIGINT).withSize(19));
+    addMetadata(
         acts, ColumnMetadata.named("ACTS").withIndex(2).ofType(Types.VARCHAR).withSize(255));
     addMetadata(
         actsKey, ColumnMetadata.named("acts_key").withIndex(3).ofType(Types.VARCHAR).withSize(255));
-    addMetadata(
-        showID, ColumnMetadata.named("Show_ID").withIndex(1).ofType(Types.BIGINT).withSize(19));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SSimpletypes_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SSimpletypes_.java
@@ -17,6 +17,8 @@ public class SSimpletypes_ extends com.querydsl.sql.RelationalPathBase<SSimplety
 
   public static final SSimpletypes_ simpletypes_ = new SSimpletypes_("simpletypes_");
 
+  public final NumberPath<Long> id = createNumber("id", Long.class);
+
   public final NumberPath<Byte> bbyte = createNumber("bbyte", Byte.class);
 
   public final NumberPath<Byte> bbyte2 = createNumber("bbyte2", Byte.class);
@@ -39,8 +41,6 @@ public class SSimpletypes_ extends com.querydsl.sql.RelationalPathBase<SSimplety
   public final NumberPath<Float> ffloat = createNumber("ffloat", Float.class);
 
   public final NumberPath<Float> ffloat2 = createNumber("ffloat2", Float.class);
-
-  public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final NumberPath<Integer> iint = createNumber("iint", Integer.class);
 
@@ -88,6 +88,8 @@ public class SSimpletypes_ extends com.querydsl.sql.RelationalPathBase<SSimplety
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         bbyte, ColumnMetadata.named("BBYTE").withIndex(2).ofType(Types.TINYINT).withSize(3));
     addMetadata(
         bbyte2, ColumnMetadata.named("BBYTE2").withIndex(3).ofType(Types.TINYINT).withSize(3));
@@ -111,8 +113,6 @@ public class SSimpletypes_ extends com.querydsl.sql.RelationalPathBase<SSimplety
         ffloat, ColumnMetadata.named("FFLOAT").withIndex(11).ofType(Types.REAL).withSize(12));
     addMetadata(
         ffloat2, ColumnMetadata.named("FFLOAT2").withIndex(12).ofType(Types.REAL).withSize(12));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         iint, ColumnMetadata.named("IINT").withIndex(13).ofType(Types.INTEGER).withSize(10));
     addMetadata(

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SStore_customer_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SStore_customer_.java
@@ -17,9 +17,9 @@ public class SStore_customer_ extends com.querydsl.sql.RelationalPathBase<SStore
 
   public static final SStore_customer_ store_customer_ = new SStore_customer_("store__customer_");
 
-  public final NumberPath<Integer> customersID = createNumber("customersID", Integer.class);
-
   public final NumberPath<Long> storeID = createNumber("storeID", Long.class);
+
+  public final NumberPath<Integer> customersID = createNumber("customersID", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SStore_customer_> primary =
       createPrimaryKey(storeID, customersID);
@@ -57,14 +57,14 @@ public class SStore_customer_ extends com.querydsl.sql.RelationalPathBase<SStore
 
   public void addMetadata() {
     addMetadata(
+        storeID,
+        ColumnMetadata.named("Store_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         customersID,
         ColumnMetadata.named("customers_ID")
             .withIndex(2)
             .ofType(Types.INTEGER)
             .withSize(10)
             .notNull());
-    addMetadata(
-        storeID,
-        ColumnMetadata.named("Store_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUser2_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUser2_.java
@@ -17,6 +17,8 @@ public class SUser2_ extends com.querydsl.sql.RelationalPathBase<SUser2_> {
 
   public static final SUser2_ user2_ = new SUser2_("user2_");
 
+  public final NumberPath<Long> id = createNumber("id", Long.class);
+
   public final NumberPath<Double> createdby = createNumber("createdby", Double.class);
 
   public final DateTimePath<java.sql.Timestamp> creationdate =
@@ -26,8 +28,6 @@ public class SUser2_ extends com.querydsl.sql.RelationalPathBase<SUser2_> {
       createDateTime("deletedate", java.sql.Timestamp.class);
 
   public final NumberPath<Double> deletedby = createNumber("deletedby", Double.class);
-
-  public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final DateTimePath<java.sql.Timestamp> modificationdate =
       createDateTime("modificationdate", java.sql.Timestamp.class);
@@ -76,6 +76,8 @@ public class SUser2_ extends com.querydsl.sql.RelationalPathBase<SUser2_> {
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         createdby,
         ColumnMetadata.named("CREATEDBY").withIndex(2).ofType(Types.DOUBLE).withSize(22));
     addMetadata(
@@ -87,8 +89,6 @@ public class SUser2_ extends com.querydsl.sql.RelationalPathBase<SUser2_> {
     addMetadata(
         deletedby,
         ColumnMetadata.named("DELETEDBY").withIndex(5).ofType(Types.DOUBLE).withSize(22));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         modificationdate,
         ColumnMetadata.named("MODIFICATIONDATE").withIndex(6).ofType(Types.TIMESTAMP).withSize(19));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUser2_userprop_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUser2_userprop_.java
@@ -17,9 +17,9 @@ public class SUser2_userprop_ extends com.querydsl.sql.RelationalPathBase<SUser2
 
   public static final SUser2_userprop_ user2_userprop_ = new SUser2_userprop_("user2__userprop_");
 
-  public final NumberPath<Long> propertiesID = createNumber("propertiesID", Long.class);
-
   public final NumberPath<Long> user2ID = createNumber("user2ID", Long.class);
+
+  public final NumberPath<Long> propertiesID = createNumber("propertiesID", Long.class);
 
   public final com.querydsl.sql.PrimaryKey<SUser2_userprop_> primary =
       createPrimaryKey(user2ID, propertiesID);
@@ -57,14 +57,14 @@ public class SUser2_userprop_ extends com.querydsl.sql.RelationalPathBase<SUser2
 
   public void addMetadata() {
     addMetadata(
+        user2ID,
+        ColumnMetadata.named("User2_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         propertiesID,
         ColumnMetadata.named("properties_ID")
             .withIndex(2)
             .ofType(Types.BIGINT)
             .withSize(19)
             .notNull());
-    addMetadata(
-        user2ID,
-        ColumnMetadata.named("User2_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUser_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUser_.java
@@ -17,15 +17,15 @@ public class SUser_ extends com.querydsl.sql.RelationalPathBase<SUser_> {
 
   public static final SUser_ user_ = new SUser_("user_");
 
-  public final NumberPath<Integer> companyId = createNumber("companyId", Integer.class);
+  public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final StringPath firstname = createString("firstname");
-
-  public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final StringPath lastname = createString("lastname");
 
   public final StringPath username = createString("username");
+
+  public final NumberPath<Integer> companyId = createNumber("companyId", Integer.class);
 
   public final com.querydsl.sql.PrimaryKey<SUser_> primary = createPrimaryKey(id);
 
@@ -62,18 +62,18 @@ public class SUser_ extends com.querydsl.sql.RelationalPathBase<SUser_> {
 
   public void addMetadata() {
     addMetadata(
-        companyId,
-        ColumnMetadata.named("COMPANY_ID").withIndex(5).ofType(Types.INTEGER).withSize(10));
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         firstname,
         ColumnMetadata.named("FIRSTNAME").withIndex(2).ofType(Types.VARCHAR).withSize(255));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         lastname,
         ColumnMetadata.named("LASTNAME").withIndex(3).ofType(Types.VARCHAR).withSize(255));
     addMetadata(
         username,
         ColumnMetadata.named("USERNAME").withIndex(4).ofType(Types.VARCHAR).withSize(255));
+    addMetadata(
+        companyId,
+        ColumnMetadata.named("COMPANY_ID").withIndex(5).ofType(Types.INTEGER).withSize(10));
   }
 }

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUserprop_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUserprop_.java
@@ -17,6 +17,8 @@ public class SUserprop_ extends com.querydsl.sql.RelationalPathBase<SUserprop_> 
 
   public static final SUserprop_ userprop_ = new SUserprop_("userprop_");
 
+  public final NumberPath<Long> id = createNumber("id", Long.class);
+
   public final StringPath categorydescription = createString("categorydescription");
 
   public final StringPath categoryname = createString("categoryname");
@@ -30,8 +32,6 @@ public class SUserprop_ extends com.querydsl.sql.RelationalPathBase<SUserprop_> 
       createDateTime("deletedate", java.sql.Timestamp.class);
 
   public final NumberPath<Double> deletedby = createNumber("deletedby", Double.class);
-
-  public final NumberPath<Long> id = createNumber("id", Long.class);
 
   public final DateTimePath<java.sql.Timestamp> modificationdate =
       createDateTime("modificationdate", java.sql.Timestamp.class);
@@ -76,6 +76,8 @@ public class SUserprop_ extends com.querydsl.sql.RelationalPathBase<SUserprop_> 
 
   public void addMetadata() {
     addMetadata(
+        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         categorydescription,
         ColumnMetadata.named("CATEGORYDESCRIPTION")
             .withIndex(2)
@@ -96,8 +98,6 @@ public class SUserprop_ extends com.querydsl.sql.RelationalPathBase<SUserprop_> 
     addMetadata(
         deletedby,
         ColumnMetadata.named("DELETEDBY").withIndex(7).ofType(Types.DOUBLE).withSize(22));
-    addMetadata(
-        id, ColumnMetadata.named("ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
     addMetadata(
         modificationdate,
         ColumnMetadata.named("MODIFICATIONDATE").withIndex(8).ofType(Types.TIMESTAMP).withSize(19));

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUserprop_category_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUserprop_category_.java
@@ -18,9 +18,9 @@ public class SUserprop_category_ extends com.querydsl.sql.RelationalPathBase<SUs
   public static final SUserprop_category_ userprop_category_ =
       new SUserprop_category_("userprop__category_");
 
-  public final NumberPath<Long> childCategoriesID = createNumber("childCategoriesID", Long.class);
-
   public final NumberPath<Long> userPropID = createNumber("userPropID", Long.class);
+
+  public final NumberPath<Long> childCategoriesID = createNumber("childCategoriesID", Long.class);
 
   public final com.querydsl.sql.PrimaryKey<SUserprop_category_> primary =
       createPrimaryKey(userPropID, childCategoriesID);
@@ -58,16 +58,16 @@ public class SUserprop_category_ extends com.querydsl.sql.RelationalPathBase<SUs
 
   public void addMetadata() {
     addMetadata(
-        childCategoriesID,
-        ColumnMetadata.named("childCategories_ID")
-            .withIndex(2)
+        userPropID,
+        ColumnMetadata.named("UserProp_ID")
+            .withIndex(1)
             .ofType(Types.BIGINT)
             .withSize(19)
             .notNull());
     addMetadata(
-        userPropID,
-        ColumnMetadata.named("UserProp_ID")
-            .withIndex(1)
+        childCategoriesID,
+        ColumnMetadata.named("childCategories_ID")
+            .withIndex(2)
             .ofType(Types.BIGINT)
             .withSize(19)
             .notNull());

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUserprop_categoryprop_.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SUserprop_categoryprop_.java
@@ -19,9 +19,9 @@ public class SUserprop_categoryprop_
   public static final SUserprop_categoryprop_ userprop_categoryprop_ =
       new SUserprop_categoryprop_("userprop__categoryprop_");
 
-  public final NumberPath<Long> propertiesID = createNumber("propertiesID", Long.class);
-
   public final NumberPath<Long> userPropID = createNumber("userPropID", Long.class);
+
+  public final NumberPath<Long> propertiesID = createNumber("propertiesID", Long.class);
 
   public final com.querydsl.sql.PrimaryKey<SUserprop_categoryprop_> primary =
       createPrimaryKey(userPropID, propertiesID);
@@ -59,16 +59,16 @@ public class SUserprop_categoryprop_
 
   public void addMetadata() {
     addMetadata(
-        propertiesID,
-        ColumnMetadata.named("properties_ID")
-            .withIndex(2)
+        userPropID,
+        ColumnMetadata.named("UserProp_ID")
+            .withIndex(1)
             .ofType(Types.BIGINT)
             .withSize(19)
             .notNull());
     addMetadata(
-        userPropID,
-        ColumnMetadata.named("UserProp_ID")
-            .withIndex(1)
+        propertiesID,
+        ColumnMetadata.named("properties_ID")
+            .withIndex(2)
             .ofType(Types.BIGINT)
             .withSize(19)
             .notNull());

--- a/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SWorldMammal.java
+++ b/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/sql/SWorldMammal.java
@@ -17,9 +17,9 @@ public class SWorldMammal extends com.querydsl.sql.RelationalPathBase<SWorldMamm
 
   public static final SWorldMammal worldMammal = new SWorldMammal("WORLD_MAMMAL");
 
-  public final NumberPath<Long> mammalsID = createNumber("mammalsID", Long.class);
-
   public final NumberPath<Long> worldID = createNumber("worldID", Long.class);
+
+  public final NumberPath<Long> mammalsID = createNumber("mammalsID", Long.class);
 
   public final com.querydsl.sql.PrimaryKey<SWorldMammal> primary =
       createPrimaryKey(worldID, mammalsID);
@@ -57,14 +57,14 @@ public class SWorldMammal extends com.querydsl.sql.RelationalPathBase<SWorldMamm
 
   public void addMetadata() {
     addMetadata(
+        worldID,
+        ColumnMetadata.named("World_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
+    addMetadata(
         mammalsID,
         ColumnMetadata.named("mammals_ID")
             .withIndex(2)
             .ofType(Types.BIGINT)
             .withSize(19)
             .notNull());
-    addMetadata(
-        worldID,
-        ColumnMetadata.named("World_ID").withIndex(1).ofType(Types.BIGINT).withSize(19).notNull());
   }
 }

--- a/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/KeyDataFactory.java
+++ b/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/KeyDataFactory.java
@@ -22,8 +22,8 @@ import com.querydsl.sql.codegen.support.PrimaryKeyData;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.TreeMap;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -74,7 +74,7 @@ public class KeyDataFactory {
       DatabaseMetaData md, String catalog, String schema, String tableName) throws SQLException {
     try (ResultSet foreignKeys = md.getExportedKeys(catalog, schema, tableName)) {
       Map<String, InverseForeignKeyData> inverseForeignKeyData =
-          new TreeMap<String, InverseForeignKeyData>();
+          new LinkedHashMap<String, InverseForeignKeyData>();
       while (foreignKeys.next()) {
         String name = foreignKeys.getString(FK_NAME);
         String parentColumnName =
@@ -108,7 +108,7 @@ public class KeyDataFactory {
   public Map<String, ForeignKeyData> getImportedKeys(
       DatabaseMetaData md, String catalog, String schema, String tableName) throws SQLException {
     try (ResultSet foreignKeys = md.getImportedKeys(catalog, schema, tableName)) {
-      Map<String, ForeignKeyData> foreignKeyData = new TreeMap<String, ForeignKeyData>();
+      Map<String, ForeignKeyData> foreignKeyData = new LinkedHashMap<String, ForeignKeyData>();
       while (foreignKeys.next()) {
         String name = foreignKeys.getString(FK_NAME);
         String parentSchemaName =
@@ -142,7 +142,7 @@ public class KeyDataFactory {
   public Map<String, PrimaryKeyData> getPrimaryKeys(
       DatabaseMetaData md, String catalog, String schema, String tableName) throws SQLException {
     try (ResultSet primaryKeys = md.getPrimaryKeys(catalog, schema, tableName)) {
-      Map<String, PrimaryKeyData> primaryKeyData = new TreeMap<String, PrimaryKeyData>();
+      Map<String, PrimaryKeyData> primaryKeyData = new LinkedHashMap<String, PrimaryKeyData>();
       while (primaryKeys.next()) {
         String name = primaryKeys.getString(PK_NAME);
         String columnName = primaryKeys.getString(PK_COLUMN_NAME);

--- a/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/KeyDataFactoryTest.java
+++ b/querydsl-sql-codegen/src/test/java/com/querydsl/sql/codegen/KeyDataFactoryTest.java
@@ -70,15 +70,15 @@ public class KeyDataFactoryTest extends AbstractJDBCTest {
         keyDataFactory.getExportedKeys(md, null, null, "EMPLOYEE");
     assertThat(exportedKeys).hasSize(2);
     Iterator<String> exportedKeysIterator = exportedKeys.keySet().iterator();
-    assertThat(exportedKeysIterator.next()).isEqualTo("FK_SUPERIOR1");
     assertThat(exportedKeysIterator.next()).isEqualTo("FK_SUPERIOR2");
+    assertThat(exportedKeysIterator.next()).isEqualTo("FK_SUPERIOR1");
     // foreign keys sorted in abc
     Map<String, ForeignKeyData> importedKeys =
         keyDataFactory.getImportedKeys(md, null, null, "EMPLOYEE");
     assertThat(importedKeys).hasSize(3);
     Iterator<String> importedKeysIterator = importedKeys.keySet().iterator();
-    assertThat(importedKeysIterator.next()).isEqualTo("FK_SUPERIOR1");
     assertThat(importedKeysIterator.next()).isEqualTo("FK_SUPERIOR2");
+    assertThat(importedKeysIterator.next()).isEqualTo("FK_SUPERIOR1");
     assertThat(importedKeysIterator.next()).isEqualTo("FK_SURVEY");
 
     // SURVEY


### PR DESCRIPTION


Type of Set on EntityType#properties impacts the order of properties in resulting Q class.
The original line dates back to 2010 and @Shredder121 explained to me that this was most likely due to desire to have deterministic behavior. TypeElement#getEnclosedElements is also deterministic so it's not exactly clear why this option was picked.The end result is that instead of having order of columns in Q class being in the same order as fields in original class, they instead end up being in ascending order.

This is problematic when, for instance, using constructor projections. IDE's, Lombok, records etc all respect the order of fields when generating full argument constructors and so parameters are in same order as their respective field counterparts. Because of this - Querydsl users that want to use constructor projections can't merely state they want it over some Q class - they need to make sure that either fields are in ascending order or they need to create constructors for which the parameters have ascending order.
