### PR TITLE
com.querydsl.sql.StatementOptions - Enable global settings and method chaining @nicofabre

### DIFF
--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/AbstractR2DBCQuery.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/AbstractR2DBCQuery.java
@@ -18,7 +18,11 @@ import com.querydsl.core.QueryException;
 import com.querydsl.core.QueryFlag;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.support.QueryMixin;
-import com.querydsl.core.types.*;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.FactoryExpression;
+import com.querydsl.core.types.ParamExpression;
+import com.querydsl.core.types.ParamNotSetException;
+import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.core.types.dsl.Wildcard;
@@ -26,8 +30,16 @@ import com.querydsl.r2dbc.binding.BindMarkers;
 import com.querydsl.r2dbc.binding.BindTarget;
 import com.querydsl.r2dbc.binding.StatementWrapper;
 import com.querydsl.sql.StatementOptions;
-import io.r2dbc.spi.*;
-import java.util.*;
+import io.r2dbc.spi.ColumnMetadata;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.Row;
+import io.r2dbc.spi.RowMetadata;
+import io.r2dbc.spi.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -375,9 +387,21 @@ public abstract class AbstractR2DBCQuery<T, Q extends AbstractR2DBCQuery<T, Q>>
    * Set the options to be applied to the JDBC statements of this query
    *
    * @param statementOptions options to be applied to statements
+   * @deprecated prefer fluent setter {@link AbstractR2DBCQuery#statementOptions(StatementOptions)}
    */
+  @Deprecated
   public void setStatementOptions(StatementOptions statementOptions) {
     this.statementOptions = statementOptions;
+  }
+
+  /**
+   * Set the options to be applied to the JDBC statements of this query
+   *
+   * @param statementOptions options to be applied to statements
+   */
+  public Q statementOptions(StatementOptions statementOptions) {
+    this.statementOptions = statementOptions;
+    return queryMixin.getSelf();
   }
 
   @FunctionalInterface

--- a/querydsl-libraries/querydsl-r2dbc/src/test/java/com/querydsl/r2dbc/SelectBase.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/test/java/com/querydsl/r2dbc/SelectBase.java
@@ -14,29 +14,93 @@
  */
 package com.querydsl.r2dbc;
 
-import static com.querydsl.core.Target.*;
-import static com.querydsl.r2dbc.Constants.*;
+import static com.querydsl.core.Target.CUBRID;
+import static com.querydsl.core.Target.DB2;
+import static com.querydsl.core.Target.DERBY;
+import static com.querydsl.core.Target.FIREBIRD;
+import static com.querydsl.core.Target.H2;
+import static com.querydsl.core.Target.HSQLDB;
+import static com.querydsl.core.Target.MYSQL;
+import static com.querydsl.core.Target.ORACLE;
+import static com.querydsl.core.Target.POSTGRESQL;
+import static com.querydsl.core.Target.SQLITE;
+import static com.querydsl.core.Target.SQLSERVER;
+import static com.querydsl.core.Target.TERADATA;
+import static com.querydsl.r2dbc.Constants.date;
+import static com.querydsl.r2dbc.Constants.employee;
+import static com.querydsl.r2dbc.Constants.employee2;
+import static com.querydsl.r2dbc.Constants.survey;
+import static com.querydsl.r2dbc.Constants.survey2;
+import static com.querydsl.r2dbc.Constants.time;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Maps;
 import com.mysema.commons.lang.Pair;
-import com.querydsl.core.*;
+import com.querydsl.core.NonUniqueResultException;
+import com.querydsl.core.QueryException;
+import com.querydsl.core.QuerydslModule;
+import com.querydsl.core.ReactiveFetchable;
+import com.querydsl.core.ReactiveQueryExecution;
+import com.querydsl.core.Target;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.testutil.ExcludeIn;
 import com.querydsl.core.testutil.IncludeIn;
 import com.querydsl.core.testutil.Serialization;
-import com.querydsl.core.types.*;
-import com.querydsl.core.types.dsl.*;
-import com.querydsl.r2dbc.domain.*;
-import com.querydsl.sql.*;
+import com.querydsl.core.types.ArrayConstructorExpression;
+import com.querydsl.core.types.Concatenation;
+import com.querydsl.core.types.Constant;
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.MappingProjection;
+import com.querydsl.core.types.Ops;
+import com.querydsl.core.types.ParamNotSetException;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Coalesce;
+import com.querydsl.core.types.dsl.DateExpression;
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.MathExpressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.core.types.dsl.Param;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.core.types.dsl.StringExpressions;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.r2dbc.domain.Employee;
+import com.querydsl.r2dbc.domain.IdName;
+import com.querydsl.r2dbc.domain.QEmployee;
+import com.querydsl.r2dbc.domain.QEmployeeNoPK;
+import com.querydsl.r2dbc.domain.QIdName;
+import com.querydsl.r2dbc.domain.QNumberTest;
+import com.querydsl.sql.Beans;
+import com.querydsl.sql.DatePart;
+import com.querydsl.sql.QBeans;
+import com.querydsl.sql.RelationalPathBase;
+import com.querydsl.sql.StatementOptions;
+import com.querydsl.sql.WithinGroup;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -2721,9 +2785,13 @@ public abstract class SelectBase extends AbstractBaseTest {
   @Test
   public void statementOptions() {
     StatementOptions options = StatementOptions.builder().setFetchSize(15).setMaxRows(150).build();
-    R2DBCQuery<?> query = query().from(employee).orderBy(employee.id.asc());
-    query.setStatementOptions(options);
-    query.select(employee.id).fetch().collectList().block();
+    var query =
+        query()
+            .from(employee)
+            .orderBy(employee.id.asc())
+            .statementOptions(options)
+            .select(employee.id);
+    query.fetch().collectList().block();
   }
 
   @Test

--- a/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
+++ b/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
@@ -14,9 +14,18 @@
 package com.querydsl.sql;
 
 import com.mysema.commons.lang.CloseableIterator;
-import com.querydsl.core.*;
+import com.querydsl.core.DefaultQueryMetadata;
+import com.querydsl.core.QueryException;
+import com.querydsl.core.QueryFlag;
+import com.querydsl.core.QueryMetadata;
+import com.querydsl.core.QueryModifiers;
+import com.querydsl.core.QueryResults;
 import com.querydsl.core.support.QueryMixin;
-import com.querydsl.core.types.*;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.FactoryExpression;
+import com.querydsl.core.types.ParamExpression;
+import com.querydsl.core.types.ParamNotSetException;
+import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.core.types.dsl.Wildcard;
@@ -26,7 +35,11 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -673,8 +686,20 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>>
    *
    * @param statementOptions options to be applied to statements
    * @return the query itslef for method chaining
+   * @deprecated prefer fluent setter {@link AbstractSQLQuery#statementOptions(StatementOptions)}
    */
-  public Q setStatementOptions(StatementOptions statementOptions) {
+  @Deprecated
+  public void setStatementOptions(StatementOptions statementOptions) {
+    this.statementOptions = statementOptions;
+  }
+
+  /**
+   * Set the options to be applied to the JDBC statements of this query
+   *
+   * @param statementOptions options to be applied to statements
+   * @return the query itslef for method chaining
+   */
+  public Q statementOptions(StatementOptions statementOptions) {
     this.statementOptions = statementOptions;
     return queryMixin.getSelf();
   }
@@ -693,6 +718,6 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>>
             .setMaxFieldSize(this.statementOptions.getMaxFieldSize())
             .setMaxRows(this.statementOptions.getMaxRows())
             .build();
-    return setStatementOptions(newStatementOptions);
+    return statementOptions(newStatementOptions);
   }
 }

--- a/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
+++ b/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/AbstractSQLQuery.java
@@ -26,11 +26,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -68,7 +64,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>>
 
   private SQLListenerContext parentContext;
 
-  private StatementOptions statementOptions = StatementOptions.DEFAULT;
+  private StatementOptions statementOptions;
 
   public AbstractSQLQuery(@Nullable Connection conn, Configuration configuration) {
     this(conn, configuration, new DefaultQueryMetadata());
@@ -80,6 +76,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>>
     this.conn = conn;
     this.listeners = new SQLListeners(configuration.getListeners());
     this.useLiterals = configuration.getUseLiterals();
+    this.statementOptions = configuration.getStatementOptions();
   }
 
   public AbstractSQLQuery(Supplier<Connection> connProvider, Configuration configuration) {
@@ -92,6 +89,7 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>>
     this.connProvider = connProvider;
     this.listeners = new SQLListeners(configuration.getListeners());
     this.useLiterals = configuration.getUseLiterals();
+    this.statementOptions = configuration.getStatementOptions();
   }
 
   /**
@@ -674,8 +672,27 @@ public abstract class AbstractSQLQuery<T, Q extends AbstractSQLQuery<T, Q>>
    * Set the options to be applied to the JDBC statements of this query
    *
    * @param statementOptions options to be applied to statements
+   * @return the query itslef for method chaining
    */
-  public void setStatementOptions(StatementOptions statementOptions) {
+  public Q setStatementOptions(StatementOptions statementOptions) {
     this.statementOptions = statementOptions;
+    return queryMixin.getSelf();
+  }
+
+  /**
+   * Set the fetch size of the JDBC statement of this query
+   *
+   * @param fetchSize the fecth size to be used by the underlying JDBC statement
+   * @return the query itslef for method chaining
+   */
+  public Q fetchSize(int fetchSize) {
+    StatementOptions newStatementOptions =
+        StatementOptions.builder()
+            .setFetchSize(fetchSize)
+            .setQueryTimeout(this.statementOptions.getQueryTimeout())
+            .setMaxFieldSize(this.statementOptions.getMaxFieldSize())
+            .setMaxRows(this.statementOptions.getMaxRows())
+            .build();
+    return setStatementOptions(newStatementOptions);
   }
 }

--- a/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
+++ b/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
@@ -66,13 +66,19 @@ public final class Configuration {
 
   private boolean useLiterals = false;
 
+  private StatementOptions statementOptions;
+
   /**
    * Create a new Configuration instance
    *
    * @param templates templates for SQL serialization
+   * @param statementOptions Default options set to the JDBC statements used by queries (JDBC fetch
+   *     size, query timeout, ...). These settings can be overridden at the query level. The ones
+   *     provided here will be used by default by all the queries created by a Query Factory
+   *     configured with this Configuration instance.
    */
   @SuppressWarnings("unchecked")
-  public Configuration(SQLTemplates templates) {
+  public Configuration(SQLTemplates templates, StatementOptions statementOptions) {
     this.templates = templates;
     for (Type<?> customType : templates.getCustomTypes()) {
       javaTypeMapping.register(customType);
@@ -109,6 +115,29 @@ public final class Configuration {
         }
       }
     }
+
+    if (statementOptions == null) {
+      throw new NullPointerException("Statement Options cannot be null");
+    }
+    this.statementOptions = statementOptions;
+  }
+
+  /**
+   * Create a new Configuration instance
+   *
+   * @param templates templates for SQL serialization
+   */
+  public Configuration(SQLTemplates templates) {
+    this(templates, StatementOptions.DEFAULT);
+  }
+
+  /**
+   * Get the {@link StatementOptions} set in this {@link Configuration}.
+   *
+   * @return as described
+   */
+  public StatementOptions getStatementOptions() {
+    return this.statementOptions;
   }
 
   /**

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -2595,7 +2595,7 @@ public abstract class SelectBase extends AbstractBaseTest {
 
     // Check that we can override the statement options on a per-query basis
     StatementOptions options2 = StatementOptions.builder().setFetchSize(15).setMaxRows(150).build();
-    query = sqlQueryFactory.from(employee).orderBy(employee.id.asc()).setStatementOptions(options2);
+    query = sqlQueryFactory.from(employee).orderBy(employee.id.asc()).statementOptions(options2);
 
     query.addListener(
         new SQLBaseListener() {


### PR DESCRIPTION
@nicofabre I replicated https://github.com/querydsl/querydsl/pull/3716 here

Add com.querydsl.sql.StatementOptions filed into Configuration object so that it can be used when a new Sql Query is created (via the Sql Query's configuration field and the configuration's statementOptions field) in order to configure the default settings for the JDBC statement used by a Sql Query.

Make the AbstractSQLQuery.setStatementOptions returning the query in order to allow method chaining.

Add AbstractSQLQuery.fetchSize method to set the JDBC fetch size (via setStatementOptions) to be used by the underlying JDBC Statement.