### PR TITLE
Support Java 16+ records in querydsl-apt @cigaly

### DIFF
--- a/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/TypeExtractor.java
+++ b/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/TypeExtractor.java
@@ -49,12 +49,13 @@ class TypeExtractor extends SimpleTypeVisitorAdapter<TypeElement, Void> {
   public TypeElement visitDeclared(DeclaredType t, Void p) {
     if (t.asElement() instanceof TypeElement) {
       TypeElement typeElement = (TypeElement) t.asElement();
-      switch (typeElement.getKind()) {
-        case ENUM:
+      switch (typeElement.getKind().name()) {
+        case "ENUM":
           return skipEnum ? null : typeElement;
-        case CLASS:
+        case "RECORD":
+        case "CLASS":
           return typeElement;
-        case INTERFACE:
+        case "INTERFACE":
           return visitInterface(t);
         default:
           throw new IllegalArgumentException("Illegal type: " + typeElement);

--- a/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/TypeExtractor.java
+++ b/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/TypeExtractor.java
@@ -14,7 +14,15 @@
 package com.querydsl.apt;
 
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.*;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ErrorType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.NullType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.WildcardType;
 
 /**
  * {@code TypeExtractor} is a visitor implementation which extracts a concrete type from a generic

--- a/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/domain/p1/SEntity1.java
+++ b/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/domain/p1/SEntity1.java
@@ -16,7 +16,4 @@ package com.querydsl.apt.domain.p1;
 import com.querydsl.core.annotations.QueryEntity;
 
 @QueryEntity
-public class SEntity1 {
-
-  String entity1Field;
-}
+public record SEntity1(String entity1Field) {}


### PR DESCRIPTION
@cigaly I replicated your fix https://github.com/querydsl/querydsl/pull/3692 here, should be released shortly


Records were first time introduced as preview feature in Java SE 14 & 15, and as completed feature in Java SE 16, almost three years ago. Hibernate is supporting records as embeddables since version 6 (see, for example, [article by Thorben Janssen](https://thorben-janssen.com/java-records-embeddables-hibernate/))

Sadly, Java records are still not supported in Querydsl APT 5.1.0.

Change to support records is trivial.since they can (mostly) be treated in a same way as "normal" classes.