### PR TITLE
Update SQL server image to 2022-latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ jobs:
     working_directory: ~/querydsl
     docker:
       - image: velo/toolchains-4-ci-builds:with-21
-      - image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+      - image: mcr.microsoft.com/mssql/server:2022-latest
         environment:
           - ACCEPT_EULA=Y
           - SA_PASSWORD=Password1!


### PR DESCRIPTION
SQL server tests were unreliable, failing with timeouts after 12 minutes. 

Trying newer version to see if problem goes away