### PR TITLE
Use dmlWithSchema also for on statement in merge-using-query, remove extra line change

### DIFF
--- a/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
+++ b/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/SQLSerializer.java
@@ -597,9 +597,10 @@ public class SQLSerializer extends SerializerBase<SQLSerializer> {
     handle(usingExpression);
     dmlWithSchema = originalDmlWithSchema;
 
-    append("\n");
     append(templates.getOn());
+    dmlWithSchema = true;
     handle(usingOn);
+    dmlWithSchema = originalDmlWithSchema;
 
     for (final SQLMergeUsingCase when : whens) {
       append("\nwhen ");


### PR DESCRIPTION
Make dmlWithSchema be true while serializing ON condition for MERGE <TABLE> USING ... ON ... so that the TABLE would have schema set correctly in the statement. This is necessary if default schema of connection is not the one where the TABLE is and also allows overriding schema using querydsl configuration.

Also remove pointless extra line change.