### PR TITLE
Explicit reference to StringTemplate

### DIFF
--- a/querydsl-tooling/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultEntitySerializer.java
+++ b/querydsl-tooling/querydsl-codegen/src/main/java/com/querydsl/codegen/DefaultEntitySerializer.java
@@ -487,6 +487,9 @@ public class DefaultEntitySerializer implements EntitySerializer {
     // other packages
     writer.imports(SimpleExpression.class.getPackage());
 
+    // explicit reference to StringTemplate
+    writer.importClasses("com.querydsl.core.types.dsl.StringTemplate");
+
     // other classes
     List<Class<?>> classes = new ArrayList<>();
     classes.add(PathMetadata.class);


### PR DESCRIPTION
Solve the problem of ambiguous reference to StringTemplate on jdk21. fix #476 