### PR TITLE
Fix AnnotationTest Class Test Case

### DIFF
--- a/querydsl-libraries/querydsl-kotlin/pom.xml
+++ b/querydsl-libraries/querydsl-kotlin/pom.xml
@@ -64,6 +64,12 @@
             <artifactId>kotlin-maven-noarg</artifactId>
             <version>${kotlin.version}</version>
           </dependency>
+          <dependency>
+            <groupId>io.github.openfeign.querydsl</groupId>
+            <artifactId>querydsl-apt</artifactId>
+            <version>${project.version}</version>
+            <classifier>general</classifier>
+          </dependency>
         </dependencies>
         <executions>
           <execution>

--- a/querydsl-tooling/querydsl-codegen-utils/pom.xml
+++ b/querydsl-tooling/querydsl-codegen-utils/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>querydsl-tooling</artifactId>
     <version>6.6-SNAPSHOT</version>
   </parent>
-  <artifactId>codegen-utils</artifactId>
+  <artifactId>querydsl-codegen-utils</artifactId>
 
   <name>Querydsl - Codegen utils</name>
   <description>Code generation and compilation for Java</description>
@@ -56,14 +56,6 @@
               <Automatic-Module-Name>com.querydsl.codegen.utils</Automatic-Module-Name>
             </manifestEntries>
           </archive>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <skipTests>true</skipTests>
         </configuration>
       </plugin>
     </plugins>

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/AbstractCodeWriter.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/AbstractCodeWriter.java
@@ -92,6 +92,6 @@ public abstract class AbstractCodeWriter<T extends AbstractCodeWriter<T>>
 
   @Override
   public T nl() throws IOException {
-    return append(System.lineSeparator());
+    return append("\n");
   }
 }

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/JDKEvaluatorFactory.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/JDKEvaluatorFactory.java
@@ -18,13 +18,11 @@ import com.querydsl.codegen.utils.model.Type;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.tools.JavaCompiler;
-import javax.tools.JavaCompiler.CompilationTask;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
@@ -44,11 +42,11 @@ public class JDKEvaluatorFactory extends AbstractEvaluatorFactory {
 
   private final JavaCompiler compiler;
 
-  public JDKEvaluatorFactory(URLClassLoader parent) {
+  public JDKEvaluatorFactory(ClassLoader parent) {
     this(parent, ToolProvider.getSystemJavaCompiler());
   }
 
-  public JDKEvaluatorFactory(URLClassLoader parent, JavaCompiler compiler) {
+  public JDKEvaluatorFactory(ClassLoader parent, JavaCompiler compiler) {
     this.fileManager =
         new MemFileManager(parent, compiler.getStandardFileManager(null, null, null));
     this.compiler = compiler;
@@ -57,6 +55,7 @@ public class JDKEvaluatorFactory extends AbstractEvaluatorFactory {
     this.compilationOptions = Arrays.asList("-classpath", classpath, "-g:none");
   }
 
+  @Override
   protected void compile(
       String source,
       ClassType projectionType,
@@ -72,7 +71,7 @@ public class JDKEvaluatorFactory extends AbstractEvaluatorFactory {
     SimpleJavaFileObject javaFileObject = new MemSourceFileObject(id, source);
     Writer out = new StringWriter();
 
-    CompilationTask task =
+    var task =
         compiler.getTask(
             out,
             fileManager,

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/SimpleCompiler.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/SimpleCompiler.java
@@ -17,8 +17,6 @@ import io.github.classgraph.ClassGraph;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,16 +32,6 @@ import javax.tools.*;
  * @author tiwe
  */
 public class SimpleCompiler implements JavaCompiler {
-
-  protected static boolean isSureFireBooter(URLClassLoader cl) {
-    for (URL url : cl.getURLs()) {
-      if (url.getPath().contains("surefirebooter")) {
-        return true;
-      }
-    }
-
-    return false;
-  }
 
   public static String getClassPath(ClassLoader cl) {
     return new ClassGraph().overrideClassLoaders(cl).getClasspath();

--- a/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/AnnotationTest.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/AnnotationTest.java
@@ -56,19 +56,25 @@ public class AnnotationTest {
   @Test
   public void Min() throws IOException {
     writer.annotation(new MinImpl(10));
-    assertThat(w.toString().trim()).isEqualTo("@javax.validation.constraints.Min(value=10)");
+    assertThat(w.toString().trim())
+        .isEqualTo(
+            "@jakarta.validation.constraints.Min(value=10, message=\"{javax.validation.constraints.Min.message}\")");
   }
 
   @Test
   public void Max() throws IOException {
     writer.annotation(new MaxImpl(10));
-    assertThat(w.toString().trim()).isEqualTo("@javax.validation.constraints.Max(value=10)");
+    assertThat(w.toString().trim())
+        .isEqualTo(
+            "@jakarta.validation.constraints.Max(value=10, message=\"{javax.validation.constraints.Max.message}\")");
   }
 
   @Test
   public void NotNull() throws IOException {
     writer.annotation(new NotNullImpl());
-    assertThat(w.toString().trim()).isEqualTo("@javax.validation.constraints.NotNull");
+    assertThat(w.toString().trim())
+        .isEqualTo(
+            "@jakarta.validation.constraints.NotNull(message=\"{javax.validation.constraints.NotNull.message}\")");
   }
 
   @Test

--- a/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/JDKEvaluatorFactoryTest.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/JDKEvaluatorFactoryTest.java
@@ -8,7 +8,6 @@ package com.querydsl.codegen.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,13 +43,13 @@ public class JDKEvaluatorFactoryTest {
 
   @Before
   public void setUp() throws IOException {
-    factory = new JDKEvaluatorFactory((URLClassLoader) getClass().getClassLoader());
+    factory = new JDKEvaluatorFactory(getClass().getClassLoader());
   }
 
   @Test
   public void Simple() {
     for (String expr : Arrays.asList("a.equals(b)", "a.startsWith(b)", "a.equalsIgnoreCase(b)")) {
-      long start = System.currentTimeMillis();
+      var start = System.currentTimeMillis();
       evaluate(
           expr,
           boolean.class,
@@ -58,12 +57,12 @@ public class JDKEvaluatorFactoryTest {
           strings,
           Arrays.asList("a", "b"),
           Collections.<String, Object>emptyMap());
-      long duration = System.currentTimeMillis() - start;
+      var duration = System.currentTimeMillis() - start;
       System.err.println(expr + " took " + duration + "ms\n");
     }
 
     for (String expr : Arrays.asList("a != b", "a < b", "a > b", "a <= b", "a >= b")) {
-      long start = System.currentTimeMillis();
+      var start = System.currentTimeMillis();
       evaluate(
           expr,
           boolean.class,
@@ -71,7 +70,7 @@ public class JDKEvaluatorFactoryTest {
           ints,
           Arrays.asList(0, 1),
           Collections.<String, Object>emptyMap());
-      long duration = System.currentTimeMillis() - start;
+      var duration = System.currentTimeMillis() - start;
       System.err.println(expr + " took " + duration + "ms\n");
     }
   }

--- a/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java
@@ -5,7 +5,6 @@
  */
 package com.querydsl.codegen.utils;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
@@ -33,16 +32,16 @@ public class SimpleCompilerTest {
   @Ignore
   public void Run() throws UnsupportedEncodingException {
     new File("target/out").mkdir();
-    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-    URLClassLoader classLoader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
+    var compiler = ToolProvider.getSystemJavaCompiler();
+    var classLoader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
 
     // create classpath
-    StringBuilder path = new StringBuilder();
+    var path = new StringBuilder();
     for (URL url : classLoader.getURLs()) {
       if (path.length() > 0) {
         path.append(File.pathSeparator);
       }
-      String decodedPath = URLDecoder.decode(url.getPath(), "UTF-8");
+      var decodedPath = URLDecoder.decode(url.getPath(), "UTF-8");
       path.append(new File(decodedPath).getAbsolutePath());
     }
     System.err.println(path);
@@ -55,7 +54,7 @@ public class SimpleCompilerTest {
             "-s",
             "target/out",
             "src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java");
-    int compilationResult =
+    var compilationResult =
         compiler.run(null, null, null, options.toArray(new String[options.size()]));
     if (compilationResult != 0) {
       fail("Compilation Failed");
@@ -71,16 +70,10 @@ public class SimpleCompilerTest {
     options.add("-s");
     options.add("target/out2");
     options.add("src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java");
-    int compilationResult =
+    var compilationResult =
         compiler.run(null, null, null, options.toArray(new String[options.size()]));
     if (compilationResult != 0) {
       fail("Compilation Failed");
     }
-  }
-
-  @Test
-  public void Surefire() {
-    URLClassLoader cl = (URLClassLoader) Thread.currentThread().getContextClassLoader();
-    assertThat(SimpleCompiler.isSureFireBooter(cl)).isTrue();
   }
 }

--- a/querydsl-tooling/querydsl-codegen/pom.xml
+++ b/querydsl-tooling/querydsl-codegen/pom.xml
@@ -25,7 +25,7 @@
     </dependency>
     <dependency>
       <groupId>io.github.openfeign.querydsl</groupId>
-      <artifactId>codegen-utils</artifactId>
+      <artifactId>querydsl-codegen-utils</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
# Fix test cases for modules in querydsl-codegen-utils

@velo 

The AnnotationTest test case was not performed properly, so it was changed to run normally. 

For test cases Via StringWriter Syntax to check whether a specific string matches an expected string. In particular, w.toString().trim() checks for a match to a certain format in an annotated string.

However, we confirmed that it was not performing normally as shown in the picture and modified the test case.

as-is 

![image](https://github.com/OpenFeign/querydsl/assets/53357210/f2a7be04-ae17-4b15-a16d-a267d6d0c6f6)
![image](https://github.com/OpenFeign/querydsl/assets/53357210/4f33ba03-8aa6-49c2-bdd7-8a77578f640c)

to-be 

<img width="892" alt="image" src="https://github.com/OpenFeign/querydsl/assets/53357210/cf1a54de-a33e-48d5-901d-ce1e8106e194">