### PR TITLE
Change incorrectly entered URL in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Use these tutorials to get started
 
 **Examples**
 
-[Querydsl example projects](https://github.com/querydsl/querydsl/tree/master/querydsl-examples)
+[Querydsl example projects](https://github.com/OpenFeign/querydsl/tree/master/querydsl-examples)
 
 **Support**
 


### PR DESCRIPTION
@velo 
hello 
README.md contains querydsl url, which is a previous project, but I am trying to change it to the example url of the current project.