### PR TITLE
A little bit of cleanup 

### DIFF
--- a/querydsl-libraries/querydsl-collections/src/test/java/com/querydsl/collections/IterationTest.java
+++ b/querydsl-libraries/querydsl-collections/src/test/java/com/querydsl/collections/IterationTest.java
@@ -47,7 +47,7 @@ public class IterationTest {
   @Test
   public void test2() {
     assertThat(
-            CollQueryFactory.<Data>from($(lt), Arrays.<Data>asList(allData.toArray(new Data[0])))
+            CollQueryFactory.<Data>from($(lt), Arrays.<Data>asList(allData.toArray(Data[]::new)))
                 .select($(lt.getData()))
                 .fetch())
         .isEqualTo(expected);
@@ -62,7 +62,7 @@ public class IterationTest {
   @Test
   public void test4() {
     assertThat(
-            CollQueryFactory.<Data>from(lt, Arrays.<Data>asList(allData.toArray(new Data[0])))
+            CollQueryFactory.<Data>from(lt, Arrays.<Data>asList(allData.toArray(Data[]::new)))
                 .select($(lt.getData()))
                 .fetch())
         .isEqualTo(expected);

--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/group/GroupByBuilder.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/group/GroupByBuilder.java
@@ -287,8 +287,7 @@ public class GroupByBuilder<K> {
       Supplier<RES> resultFactory, FactoryExpression<V> expression) {
     final FactoryExpression<V> transformation = FactoryExpressionUtils.wrap(expression);
     var args = transformation.getArgs();
-    return new GroupByGenericCollection<>(
-        resultFactory, key, args.toArray(new Expression<?>[args.size()])) {
+    return new GroupByGenericCollection<>(resultFactory, key, args.toArray(new Expression<?>[0])) {
       @Override
       protected V transform(Group group) {
         // XXX Isn't group.toArray() suitable here?

--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/group/GroupByBuilder.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/group/GroupByBuilder.java
@@ -287,7 +287,7 @@ public class GroupByBuilder<K> {
       Supplier<RES> resultFactory, FactoryExpression<V> expression) {
     final FactoryExpression<V> transformation = FactoryExpressionUtils.wrap(expression);
     var args = transformation.getArgs();
-    return new GroupByGenericCollection<>(resultFactory, key, args.toArray(new Expression<?>[0])) {
+    return new GroupByGenericCollection<>(resultFactory, key, args.toArray(Expression[]::new)) {
       @Override
       protected V transform(Group group) {
         // XXX Isn't group.toArray() suitable here?

--- a/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/MatchingFiltersFactory.java
+++ b/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/MatchingFiltersFactory.java
@@ -119,8 +119,7 @@ public class MatchingFiltersFactory {
       DateExpression<java.sql.Date> expr,
       DateExpression<java.sql.Date> other,
       java.sql.Date knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(date(expr, other));
+    var rv = new HashSet<>(date(expr, other));
     rv.addAll(date(expr, DateConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }
@@ -160,8 +159,7 @@ public class MatchingFiltersFactory {
       DateTimeExpression<java.util.Date> expr,
       DateTimeExpression<java.util.Date> other,
       java.util.Date knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(dateTime(expr, other));
+    var rv = new HashSet<>(dateTime(expr, other));
     rv.addAll(dateTime(expr, DateTimeConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }
@@ -191,8 +189,7 @@ public class MatchingFiltersFactory {
 
   public <A extends Number & Comparable<A>> Collection<Predicate> numeric(
       NumberExpression<A> expr, NumberExpression<A> other, A knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(numeric(expr, other));
+    var rv = new HashSet<Predicate>(numeric(expr, other));
     rv.addAll(numeric(expr, NumberConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }
@@ -321,8 +318,7 @@ public class MatchingFiltersFactory {
 
   public Collection<Predicate> string(
       StringExpression expr, StringExpression other, String knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(string(expr, other));
+    var rv = new HashSet<Predicate>(string(expr, other));
     rv.addAll(string(expr, StringConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }
@@ -341,8 +337,7 @@ public class MatchingFiltersFactory {
       TimeExpression<java.sql.Time> expr,
       TimeExpression<java.sql.Time> other,
       java.sql.Time knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(time(expr, other));
+    var rv = new HashSet<>(time(expr, other));
     rv.addAll(time(expr, TimeConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }

--- a/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/ProjectionsFactory.java
+++ b/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/ProjectionsFactory.java
@@ -124,8 +124,7 @@ public class ProjectionsFactory {
 
   public <A extends Number & Comparable<A>> Collection<NumberExpression<?>> numeric(
       NumberExpression<A> expr, NumberExpression<A> other, A knownValue, boolean forFilter) {
-    var rv = new HashSet<NumberExpression<?>>();
-    rv.addAll(numeric(expr, other, forFilter));
+    var rv = new HashSet<>(numeric(expr, other, forFilter));
     rv.addAll(numeric(expr, NumberConstant.create(knownValue), forFilter));
     return Collections.unmodifiableSet(rv);
   }
@@ -193,8 +192,7 @@ public class ProjectionsFactory {
 
   public Collection<SimpleExpression<String>> string(
       StringExpression expr, StringExpression other, String knownValue) {
-    var rv = new HashSet<SimpleExpression<String>>();
-    rv.addAll(stringProjections(expr, other));
+    var rv = new HashSet<>(stringProjections(expr, other));
     rv.addAll(stringProjections(expr, StringConstant.create(knownValue)));
     return rv;
   }

--- a/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/ReactiveQueryExecution.java
+++ b/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/ReactiveQueryExecution.java
@@ -98,11 +98,21 @@ public abstract class ReactiveQueryExecution {
 
   private Throwable addError(Expression<?> expr, Throwable throwable) {
     var error = new StringBuilder();
-    error.append(expr + " failed : \n");
-    error.append(" " + throwable.getClass().getName() + " : " + throwable.getMessage() + "\n");
+    error.append(expr).append(" failed : \n");
+    error
+        .append(" ")
+        .append(throwable.getClass().getName())
+        .append(" : ")
+        .append(throwable.getMessage())
+        .append("\n");
     if (throwable.getCause() != null) {
       throwable = throwable.getCause();
-      error.append(" " + throwable.getClass().getName() + " : " + throwable.getMessage() + "\n");
+      error
+          .append(" ")
+          .append(throwable.getClass().getName())
+          .append(" : ")
+          .append(throwable.getMessage())
+          .append("\n");
     }
     errors.add(error.toString());
     return throwable;
@@ -207,10 +217,10 @@ public abstract class ReactiveQueryExecution {
       }
       buffer.append("of ").append(total).append(" tests\n");
       for (String f : failures) {
-        buffer.append(f + "\n");
+        buffer.append(f).append("\n");
       }
       for (String e : errors) {
-        buffer.append(e + "\n");
+        buffer.append(e).append("\n");
       }
       Assert.fail(buffer.toString());
     } else {

--- a/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/types/TemplatesTestUtils.java
+++ b/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/types/TemplatesTestUtils.java
@@ -2,7 +2,12 @@ package com.querydsl.core.types;
 
 import static org.assertj.core.api.Assertions.fail;
 
+import java.util.regex.Pattern;
+
 public final class TemplatesTestUtils {
+
+  private static final Pattern PATTERN = Pattern.compile(".*[<>] ?\\-?\\d");
+  private static final Pattern REGEX = Pattern.compile(".*[\\+\\-] ?\\-?\\d");
 
   public static void testPrecedence(Templates templates) {
     var likePrecedence = templates.getPrecedence(Ops.LIKE);
@@ -21,11 +26,11 @@ public final class TemplatesTestUtils {
         fail("Unexpected precedence for " + op + " with template " + template);
       } else if (!str.contains("(") && !str.contains(".") && precedence < 0) {
         fail("Unexpected precedence for " + op + " with template " + template);
-      } else if (str.matches(".*[<>] ?\\-?\\d")) {
+      } else if (PATTERN.matcher(str).matches()) {
         if (precedence != Templates.Precedence.COMPARISON) {
           fail("Unsafe pattern for " + op + " with template " + template);
         }
-      } else if (str.matches(".*[\\+\\-] ?\\-?\\d")) {
+      } else if (REGEX.matcher(str).matches()) {
         if (precedence != Templates.Precedence.ARITH_LOW
             && precedence != Templates.Precedence.ARITH_HIGH) {
           fail("Unsafe pattern for " + op + " with template " + template);

--- a/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/types/VisitorTest.java
+++ b/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/types/VisitorTest.java
@@ -22,9 +22,8 @@ public class VisitorTest {
 
   @Test
   public void iteration() throws SecurityException, NoSuchMethodException {
-    List<Class<?>> types = new ArrayList<>();
+    List<Class<?>> types = new ArrayList<>(Arrays.asList(Operation.class.getClasses()));
     //        types.addAll(Arrays.<Class<?>>asList(Alias.class.getClasses()));
-    types.addAll(Arrays.asList(Operation.class.getClasses()));
     types.addAll(Arrays.asList(Path.class.getClasses()));
     for (Class<?> innerType : types) {
       if (!innerType.isInterface() && Expression.class.isAssignableFrom(innerType)) {

--- a/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/types/VisitorTest.java
+++ b/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/types/VisitorTest.java
@@ -15,14 +15,13 @@ package com.querydsl.core.types;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import org.junit.Test;
 
 public class VisitorTest {
 
   @Test
   public void iteration() throws SecurityException, NoSuchMethodException {
-    List<Class<?>> types = new ArrayList<>(Arrays.asList(Operation.class.getClasses()));
+    var types = new ArrayList<>(Arrays.asList(Operation.class.getClasses()));
     //        types.addAll(Arrays.<Class<?>>asList(Alias.class.getClasses()));
     types.addAll(Arrays.asList(Path.class.getClasses()));
     for (Class<?> innerType : types) {

--- a/querydsl-libraries/querydsl-jpa-spring/src/main/java/io/github/openfeign/querydsl/jpa/spring/repository/support/QuerydslJpaRepositoryFactoryBean.java
+++ b/querydsl-libraries/querydsl-jpa-spring/src/main/java/io/github/openfeign/querydsl/jpa/spring/repository/support/QuerydslJpaRepositoryFactoryBean.java
@@ -69,7 +69,7 @@ public class QuerydslJpaRepositoryFactoryBean<T extends JPQLRepository<S, ID>, S
     protected RepositoryFragments getRepositoryFragments(RepositoryMetadata metadata) {
 
       var fragmentImplementation =
-          getTargetRepositoryViaReflection( //
+          instantiateClass( //
               QuerydslJpaRepositoryImpl.class, //
               getEntityInformation(metadata.getDomainType()), //
               entityManager //

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAQueryMixin.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAQueryMixin.java
@@ -158,9 +158,8 @@ public class JPAQueryMixin<T> extends QueryMixin<T> {
     var metadata = path.getMetadata();
     // at least three levels
     if (metadata.getParent() != null && !metadata.getParent().getMetadata().isRoot()) {
-      Set<Expression<?>> exprs = new HashSet<>();
       var md = getMetadata();
-      exprs.addAll(md.getGroupBy());
+      Set<Expression<?>> exprs = new HashSet<>(md.getGroupBy());
       if (md.getProjection() != null) {
         exprs.add(md.getProjection());
       }

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAQueryMixin.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPAQueryMixin.java
@@ -159,7 +159,7 @@ public class JPAQueryMixin<T> extends QueryMixin<T> {
     // at least three levels
     if (metadata.getParent() != null && !metadata.getParent().getMetadata().isRoot()) {
       var md = getMetadata();
-      Set<Expression<?>> exprs = new HashSet<>(md.getGroupBy());
+      var exprs = new HashSet<>(md.getGroupBy());
       if (md.getProjection() != null) {
         exprs.add(md.getProjection());
       }

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/UniqueResultsTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/UniqueResultsTest.java
@@ -32,9 +32,9 @@ public class UniqueResultsTest implements HibernateTest {
 
   @Test
   public void test() {
-    session.save(new Cat("Bob1", 1));
-    session.save(new Cat("Bob2", 2));
-    session.save(new Cat("Bob3", 3));
+    session.persist(new Cat("Bob1", 1));
+    session.persist(new Cat("Bob2", 2));
+    session.persist(new Cat("Bob3", 3));
 
     assertThat(
             query()

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/AbstractR2DBCQuery.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/AbstractR2DBCQuery.java
@@ -259,8 +259,7 @@ public abstract class AbstractR2DBCQuery<T, Q extends AbstractR2DBCQuery<T, Q>>
   }
 
   private T toWildcardObjectArray(Row row, RowMetadata meta) {
-    var metaList = new ArrayList<ColumnMetadata>();
-    meta.getColumnMetadatas().forEach(metaList::add);
+    var metaList = new ArrayList<ColumnMetadata>(meta.getColumnMetadatas());
 
     var args = new Object[metaList.size()];
     for (var i = 0; i < args.length; i++) {

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/Configuration.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/Configuration.java
@@ -169,10 +169,10 @@ public final class Configuration {
           typeName = typeName.substring(0, typeName.length() - 6);
         }
         if (typeName.contains("[")) {
-          typeName = typeName.substring(0, typeName.indexOf("["));
+          typeName = typeName.substring(0, typeName.indexOf('['));
         }
         if (typeName.contains("(")) {
-          typeName = typeName.substring(0, typeName.indexOf("("));
+          typeName = typeName.substring(0, typeName.indexOf('('));
         }
 
         var sqlComponentType = templates.getCodeForTypeName(typeName);

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/R2DBCRelationalFunctionCall.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/R2DBCRelationalFunctionCall.java
@@ -40,7 +40,7 @@ public class R2DBCRelationalFunctionCall<T> extends SimpleExpression<T>
       if (i > 0) {
         builder.append(", ");
       }
-      builder.append("{" + i + "}");
+      builder.append("{").append(i).append("}");
     }
     builder.append(")");
     return TemplateFactory.DEFAULT.create(builder.toString());

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/SQLTemplates.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/SQLTemplates.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * {@code SQLTemplates} extends {@link Templates} to provides SQL specific extensions and acts as
@@ -81,6 +82,8 @@ public class SQLTemplates extends Templates {
               Ops.STARTS_WITH_IC,
               Ops.STRING_CONTAINS,
               Ops.STRING_CONTAINS_IC));
+  private static final Pattern PATTERN = Pattern.compile(".*[^A-z0-9_].*");
+  private static final Pattern REGEX = Pattern.compile("^[^A-z_].*");
 
   private final Set<String> reservedWords;
 
@@ -91,9 +94,9 @@ public class SQLTemplates extends Templates {
   private final List<Type<?, ?>> customTypes = new ArrayList<>();
 
   protected boolean requiresQuotes(final String identifier, final boolean precededByDot) {
-    if (identifier.matches(".*[^A-z0-9_].*")) {
+    if (PATTERN.matcher(identifier).matches()) {
       return true;
-    } else if (identifier.matches("^[^A-z_].*")) {
+    } else if (REGEX.matcher(identifier).matches()) {
       return true;
     } else if (precededByDot && supportsUnquotedReservedWordsAsIdentifier) {
       return false;

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/dml/AbstractR2DBCInsertClause.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/dml/AbstractR2DBCInsertClause.java
@@ -209,7 +209,7 @@ public abstract class AbstractR2DBCInsertClause<C extends AbstractR2DBCInsertCla
 
   protected Statement createStatement(Connection connection, boolean withKeys) {
     if (subQueryBuilder != null) {
-      subQuery = subQueryBuilder.select(values.toArray(new Expression[0])).clone();
+      subQuery = subQueryBuilder.select(values.toArray(Expression[]::new)).clone();
       values.clear();
     }
 
@@ -219,7 +219,7 @@ public abstract class AbstractR2DBCInsertClause<C extends AbstractR2DBCInsertCla
 
   protected Statement createStatements(Connection connection, boolean withKeys) {
     if (subQueryBuilder != null) {
-      subQuery = subQueryBuilder.select(values.toArray(new Expression[0])).clone();
+      subQuery = subQueryBuilder.select(values.toArray(Expression[]::new)).clone();
       values.clear();
     }
 

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/dml/AbstractR2DBCInsertClause.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/dml/AbstractR2DBCInsertClause.java
@@ -209,7 +209,7 @@ public abstract class AbstractR2DBCInsertClause<C extends AbstractR2DBCInsertCla
 
   protected Statement createStatement(Connection connection, boolean withKeys) {
     if (subQueryBuilder != null) {
-      subQuery = subQueryBuilder.select(values.toArray(new Expression[values.size()])).clone();
+      subQuery = subQueryBuilder.select(values.toArray(new Expression[0])).clone();
       values.clear();
     }
 
@@ -219,7 +219,7 @@ public abstract class AbstractR2DBCInsertClause<C extends AbstractR2DBCInsertCla
 
   protected Statement createStatements(Connection connection, boolean withKeys) {
     if (subQueryBuilder != null) {
-      subQuery = subQueryBuilder.select(values.toArray(new Expression[values.size()])).clone();
+      subQuery = subQueryBuilder.select(values.toArray(new Expression[0])).clone();
       values.clear();
     }
 

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/group/ReactiveAbstractGroupByTransformer.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/group/ReactiveAbstractGroupByTransformer.java
@@ -98,7 +98,7 @@ public abstract class ReactiveAbstractGroupByTransformer<K, T>
       }
     }
 
-    this.expressions = projection.toArray(new Expression[projection.size()]);
+    this.expressions = projection.toArray(new Expression[0]);
   }
 
   protected static FactoryExpression<Tuple> withoutGroupExpressions(

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/group/ReactiveAbstractGroupByTransformer.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/group/ReactiveAbstractGroupByTransformer.java
@@ -98,7 +98,7 @@ public abstract class ReactiveAbstractGroupByTransformer<K, T>
       }
     }
 
-    this.expressions = projection.toArray(new Expression[0]);
+    this.expressions = projection.toArray(Expression[]::new);
   }
 
   protected static FactoryExpression<Tuple> withoutGroupExpressions(

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/group/ReactiveGroupByBuilder.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/group/ReactiveGroupByBuilder.java
@@ -120,7 +120,7 @@ public class ReactiveGroupByBuilder<K> {
   public <V> ReactiveResultTransformer<Map<K, V>> as(FactoryExpression<V> expression) {
     final FactoryExpression<?> transformation = FactoryExpressionUtils.wrap(expression);
     var args = transformation.getArgs();
-    return new ReactiveGroupByMap<K, V>(key, args.toArray(new Expression<?>[args.size()])) {
+    return new ReactiveGroupByMap<K, V>(key, args.toArray(new Expression<?>[0])) {
 
       @Override
       protected Map<K, V> transform(Map<K, Group> groups) {
@@ -152,7 +152,7 @@ public class ReactiveGroupByBuilder<K> {
   public <V> ReactiveResultTransformer<V> flux(FactoryExpression<V> expression) {
     final FactoryExpression<V> transformation = FactoryExpressionUtils.wrap(expression);
     var args = transformation.getArgs();
-    return new ReactiveGroupByList<>(key, args.toArray(new Expression<?>[args.size()])) {
+    return new ReactiveGroupByList<>(key, args.toArray(new Expression<?>[0])) {
       @Override
       protected V transform(Group group) {
         // XXX Isn't group.toArray() suitable here?

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/group/ReactiveGroupByBuilder.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/group/ReactiveGroupByBuilder.java
@@ -120,7 +120,7 @@ public class ReactiveGroupByBuilder<K> {
   public <V> ReactiveResultTransformer<Map<K, V>> as(FactoryExpression<V> expression) {
     final FactoryExpression<?> transformation = FactoryExpressionUtils.wrap(expression);
     var args = transformation.getArgs();
-    return new ReactiveGroupByMap<K, V>(key, args.toArray(new Expression<?>[0])) {
+    return new ReactiveGroupByMap<K, V>(key, args.toArray(Expression[]::new)) {
 
       @Override
       protected Map<K, V> transform(Map<K, Group> groups) {
@@ -152,7 +152,7 @@ public class ReactiveGroupByBuilder<K> {
   public <V> ReactiveResultTransformer<V> flux(FactoryExpression<V> expression) {
     final FactoryExpression<V> transformation = FactoryExpressionUtils.wrap(expression);
     var args = transformation.getArgs();
-    return new ReactiveGroupByList<>(key, args.toArray(new Expression<?>[0])) {
+    return new ReactiveGroupByList<>(key, args.toArray(Expression[]::new)) {
       @Override
       protected V transform(Group group) {
         // XXX Isn't group.toArray() suitable here?

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/mysql/R2DBCMySQLQueryFactory.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/mysql/R2DBCMySQLQueryFactory.java
@@ -98,7 +98,7 @@ public class R2DBCMySQLQueryFactory extends AbstractR2DBCQueryFactory<R2DBCMySQL
     var insert = insert(entity);
     var flag = new StringBuilder(" on duplicate key update ");
     for (var i = 0; i < clauses.length; i++) {
-      flag.append(i > 0 ? ", " : "").append("{" + i + "}");
+      flag.append(i > 0 ? ", " : "").append("{").append(i).append("}");
     }
     insert.addFlag(Position.END, ExpressionUtils.template(String.class, flag.toString(), clauses));
     return insert;

--- a/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/types/URLType.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/main/java/com/querydsl/r2dbc/types/URLType.java
@@ -15,6 +15,7 @@ package com.querydsl.r2dbc.types;
 
 import io.r2dbc.spi.Row;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.sql.Types;
 
@@ -37,7 +38,7 @@ public class URLType extends AbstractType<URL, String> {
   public URL getValue(Row row, int startIndex) {
     var val = row.get(startIndex, String.class);
     try {
-      return val != null ? new URL(val) : null;
+      return val != null ? URI.create(val).toURL() : null;
     } catch (MalformedURLException e) {
       return null;
     }

--- a/querydsl-libraries/querydsl-r2dbc/src/test/java/com/querydsl/r2dbc/R2DBCMatchingFiltersFactory.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/test/java/com/querydsl/r2dbc/R2DBCMatchingFiltersFactory.java
@@ -93,8 +93,7 @@ public class R2DBCMatchingFiltersFactory {
 
   public Collection<Predicate> date(
       LocalDateExpression<LocalDate> expr, LocalDateExpression<LocalDate> other) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(comparable(expr, other));
+    var rv = new HashSet<>(comparable(expr, other));
     rv.add(expr.dayOfMonth().eq(other.dayOfMonth()));
 
     if (!target.equals(Target.DERBY)
@@ -124,16 +123,14 @@ public class R2DBCMatchingFiltersFactory {
       LocalDateExpression<LocalDate> expr,
       LocalDateExpression<LocalDate> other,
       LocalDate knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(date(expr, other));
+    var rv = new HashSet<>(date(expr, other));
     rv.addAll(date(expr, R2DBCDateConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }
 
   public Collection<Predicate> dateTime(
       LocalDateTimeExpression<LocalDateTime> expr, LocalDateTimeExpression<LocalDateTime> other) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(comparable(expr, other));
+    var rv = new HashSet<>(comparable(expr, other));
     rv.add(expr.milliSecond().eq(other.milliSecond()));
     rv.add(expr.second().eq(other.second()));
     rv.add(expr.minute().eq(other.minute()));
@@ -166,8 +163,7 @@ public class R2DBCMatchingFiltersFactory {
       LocalDateTimeExpression<LocalDateTime> expr,
       LocalDateTimeExpression<LocalDateTime> other,
       LocalDateTime knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(dateTime(expr, other));
+    var rv = new HashSet<>(dateTime(expr, other));
     rv.addAll(dateTime(expr, R2DBCDateTimeConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }
@@ -197,8 +193,7 @@ public class R2DBCMatchingFiltersFactory {
 
   public <A extends Number & Comparable<A>> Collection<Predicate> numeric(
       NumberExpression<A> expr, NumberExpression<A> other, A knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(numeric(expr, other));
+    var rv = new HashSet<>(numeric(expr, other));
     rv.addAll(numeric(expr, NumberConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }
@@ -327,16 +322,14 @@ public class R2DBCMatchingFiltersFactory {
 
   public Collection<Predicate> string(
       StringExpression expr, StringExpression other, String knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(string(expr, other));
+    var rv = new HashSet<Predicate>(string(expr, other));
     rv.addAll(string(expr, StringConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }
 
   public Collection<Predicate> time(
       LocalTimeExpression<LocalTime> expr, LocalTimeExpression<LocalTime> other) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(comparable(expr, other));
+    var rv = new HashSet<>(comparable(expr, other));
     rv.add(expr.milliSecond().eq(other.milliSecond()));
     rv.add(expr.second().eq(other.second()));
     rv.add(expr.minute().eq(other.minute()));
@@ -348,8 +341,7 @@ public class R2DBCMatchingFiltersFactory {
       LocalTimeExpression<LocalTime> expr,
       LocalTimeExpression<LocalTime> other,
       LocalTime knownValue) {
-    var rv = new HashSet<Predicate>();
-    rv.addAll(time(expr, other));
+    var rv = new HashSet<>(time(expr, other));
     rv.addAll(time(expr, R2DBCTimeConstant.create(knownValue)));
     return Collections.unmodifiableSet(rv);
   }

--- a/querydsl-libraries/querydsl-r2dbc/src/test/java/com/querydsl/r2dbc/UnionBase.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/test/java/com/querydsl/r2dbc/UnionBase.java
@@ -61,7 +61,7 @@ public abstract class UnionBase extends AbstractBaseTest {
   public void union_list() {
     SubQueryExpression<Integer> sq1 = query().from(employee).select(employee.id.max());
     SubQueryExpression<Integer> sq2 = query().from(employee).select(employee.id.min());
-    assertThat(query().union(sq1, sq2).list().collectList().block())
+    assertThat(query().union(sq1, sq2).fetch().collectList().block())
         .isEqualTo(query().union(sq1, sq2).fetch().collectList().block());
   }
 

--- a/querydsl-libraries/querydsl-r2dbc/src/test/java/com/querydsl/r2dbc/ddl/CreateTableClause.java
+++ b/querydsl-libraries/querydsl-r2dbc/src/test/java/com/querydsl/r2dbc/ddl/CreateTableClause.java
@@ -150,14 +150,14 @@ public class CreateTableClause {
   @SuppressWarnings("SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE")
   public Mono<Void> execute() {
     var builder = new StringBuilder();
-    builder.append(templates.getCreateTable() + table + " (\n");
+    builder.append(templates.getCreateTable()).append(table).append(" (\n");
     List<String> lines = new ArrayList<>(columns.size() + foreignKeys.size() + 1);
     // columns
     for (ColumnData column : columns) {
       var line = new StringBuilder();
-      line.append(column.getName() + " " + column.getType().toUpperCase());
+      line.append(column.getName()).append(" ").append(column.getType().toUpperCase());
       if (column.getSize() != null) {
-        line.append("(" + column.getSize() + ")");
+        line.append("(").append(column.getSize()).append(")");
       }
       if (!column.isNullAllowed()) {
         line.append(templates.getNotNull().toUpperCase());
@@ -171,25 +171,26 @@ public class CreateTableClause {
     // primary key
     if (primaryKey != null) {
       var line = new StringBuilder();
-      line.append("CONSTRAINT " + primaryKey.getName() + " ");
-      line.append("PRIMARY KEY(" + COMMA_JOINER.join(primaryKey.getColumns()) + ")");
+      line.append("CONSTRAINT ").append(primaryKey.getName()).append(" ");
+      line.append("PRIMARY KEY(").append(COMMA_JOINER.join(primaryKey.getColumns())).append(")");
       lines.add(line.toString());
     }
 
     // foreign keys
     for (ForeignKeyData foreignKey : foreignKeys) {
       var line = new StringBuilder();
-      line.append("CONSTRAINT " + foreignKey.getName() + " ");
-      line.append("FOREIGN KEY(" + COMMA_JOINER.join(foreignKey.getForeignColumns()) + ") ");
-      line.append(
-          "REFERENCES "
-              + foreignKey.getTable()
-              + "("
-              + COMMA_JOINER.join(foreignKey.getParentColumns())
-              + ")");
+      line.append("CONSTRAINT ").append(foreignKey.getName()).append(" ");
+      line.append("FOREIGN KEY(")
+          .append(COMMA_JOINER.join(foreignKey.getForeignColumns()))
+          .append(") ");
+      line.append("REFERENCES ")
+          .append(foreignKey.getTable())
+          .append("(")
+          .append(COMMA_JOINER.join(foreignKey.getParentColumns()))
+          .append(")");
       lines.add(line.toString());
     }
-    builder.append("  " + Joiner.on(",\n  ").join(lines));
+    builder.append("  ").append(Joiner.on(",\n  ").join(lines));
     builder.append("\n)\n");
     // logger.info(builder.toString());
 

--- a/querydsl-libraries/querydsl-spatial/src/main/java/com/querydsl/spatial/apt/SpatialSupport.java
+++ b/querydsl-libraries/querydsl-spatial/src/main/java/com/querydsl/spatial/apt/SpatialSupport.java
@@ -77,8 +77,7 @@ public final class SpatialSupport implements Extension {
       imports = Collections.singleton(packageName);
     } else {
       var old = imports;
-      imports = new HashSet<>();
-      imports.addAll(old);
+      imports = new HashSet<>(old);
       imports.add(packageName);
     }
     module.bind(CodegenModule.IMPORTS, imports);

--- a/querydsl-libraries/querydsl-sql-json/src/main/java/io/github/openfeign/querydsl/sql/json/JsonSupport.java
+++ b/querydsl-libraries/querydsl-sql-json/src/main/java/io/github/openfeign/querydsl/sql/json/JsonSupport.java
@@ -41,8 +41,7 @@ public final class JsonSupport implements Extension {
       imports = Collections.singleton(packageName);
     } else {
       var old = imports;
-      imports = new HashSet<>();
-      imports.addAll(old);
+      imports = new HashSet<>(old);
       imports.add(packageName);
     }
     module.bind(CodegenModule.IMPORTS, imports);

--- a/querydsl-libraries/querydsl-sql-json/src/main/java/io/github/openfeign/querydsl/sql/json/types/JSONType.java
+++ b/querydsl-libraries/querydsl-sql-json/src/main/java/io/github/openfeign/querydsl/sql/json/types/JSONType.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.querydsl.sql.types.Type;
 import io.github.openfeign.querydsl.sql.json.JsonEntity;
 import java.io.IOException;
@@ -22,12 +23,14 @@ public class JSONType implements Type<JsonEntity> {
   }
 
   public JSONType() {
-    objectMapper = new ObjectMapper();
-    objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
-    objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    objectMapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
-    objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+    objectMapper =
+        JsonMapper.builder()
+            .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true)
+            .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
+            .build();
   }
 
   @Override

--- a/querydsl-libraries/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/SpatialBase.java
+++ b/querydsl-libraries/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/SpatialBase.java
@@ -267,8 +267,8 @@ public class SpatialBase extends AbstractBaseTest {
     var shapes1 = QShapes.shapes;
     var shapes2 = new QShapes("shapes2");
 
-    List<Expression<?>> expressions = new ArrayList<>();
-    expressions.addAll(createExpressions(shapes1.geometry.asPoint(), shapes2.geometry.asPoint()));
+    List<Expression<?>> expressions =
+        new ArrayList<>(createExpressions(shapes1.geometry.asPoint(), shapes2.geometry.asPoint()));
     expressions.addAll(
         createExpressions(
             shapes1.geometry.asPoint(), ConstantImpl.create((Point) Wkt.fromWkt("Point(2 2)"))));

--- a/querydsl-libraries/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/SpatialBase.java
+++ b/querydsl-libraries/querydsl-sql-spatial/src/test/java/com/querydsl/sql/spatial/SpatialBase.java
@@ -267,7 +267,7 @@ public class SpatialBase extends AbstractBaseTest {
     var shapes1 = QShapes.shapes;
     var shapes2 = new QShapes("shapes2");
 
-    List<Expression<?>> expressions =
+    var expressions =
         new ArrayList<>(createExpressions(shapes1.geometry.asPoint(), shapes2.geometry.asPoint()));
     expressions.addAll(
         createExpressions(

--- a/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
+++ b/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/Configuration.java
@@ -195,10 +195,10 @@ public final class Configuration {
           typeName = typeName.substring(0, typeName.length() - 6);
         }
         if (typeName.contains("[")) {
-          typeName = typeName.substring(0, typeName.indexOf("["));
+          typeName = typeName.substring(0, typeName.indexOf('['));
         }
         if (typeName.contains("(")) {
-          typeName = typeName.substring(0, typeName.indexOf("("));
+          typeName = typeName.substring(0, typeName.indexOf('('));
         }
 
         var sqlComponentType = templates.getCodeForTypeName(typeName);

--- a/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
+++ b/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/SQLTemplates.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * {@code SQLTemplates} extends {@link Templates} to provides SQL specific extensions and acts as
@@ -76,6 +77,8 @@ public class SQLTemplates extends Templates {
               Ops.STARTS_WITH_IC,
               Ops.STRING_CONTAINS,
               Ops.STRING_CONTAINS_IC));
+  private static final Pattern PATTERN = Pattern.compile(".*[^A-z0-9_].*");
+  private static final Pattern REGEX = Pattern.compile("^[^A-z_].*");
 
   private final Set<String> reservedWords;
 
@@ -850,9 +853,9 @@ public class SQLTemplates extends Templates {
   }
 
   protected boolean requiresQuotes(final String identifier, final boolean precededByDot) {
-    if (identifier.matches(".*[^A-z0-9_].*")) {
+    if (PATTERN.matcher(identifier).matches()) {
       return true;
-    } else if (identifier.matches("^[^A-z_].*")) {
+    } else if (REGEX.matcher(identifier).matches()) {
       return true;
     } else if (precededByDot && supportsUnquotedReservedWordsAsIdentifier) {
       return false;

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -641,14 +641,13 @@ public abstract class SelectBase extends AbstractBaseTest {
       var message = new StringBuilder();
       for (Map.Entry<Object, Object> entry : failures.entrySet()) {
         message
-            .append(
-                entry.getKey().getClass().getName()
-                    + " != "
-                    + entry.getValue().getClass().getName()
-                    + ": "
-                    + entry.getKey()
-                    + " != "
-                    + entry.getValue())
+            .append(entry.getKey().getClass().getName())
+            .append(" != ")
+            .append(entry.getValue().getClass().getName())
+            .append(": ")
+            .append(entry.getKey())
+            .append(" != ")
+            .append(entry.getValue())
             .append('\n');
       }
       fail("Failed with " + message);

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/UnionBase.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/UnionBase.java
@@ -61,7 +61,7 @@ public abstract class UnionBase extends AbstractBaseTest {
   public void union_list() throws SQLException {
     SubQueryExpression<Integer> sq1 = query().from(employee).select(employee.id.max());
     SubQueryExpression<Integer> sq2 = query().from(employee).select(employee.id.min());
-    assertThat(query().union(sq1, sq2).list()).isEqualTo(query().union(sq1, sq2).fetch());
+    assertThat(query().union(sq1, sq2).fetch()).isEqualTo(query().union(sq1, sq2).fetch());
   }
 
   @Test
@@ -215,7 +215,7 @@ public abstract class UnionBase extends AbstractBaseTest {
     SubQueryExpression<Tuple> sq2 =
         query().from(employee).select(employee.id.min(), employee.id.min().subtract(1));
 
-    var list = query().union(sq1, sq2).list();
+    var list = query().union(sq1, sq2).fetch();
     assertThat(list).hasSize(2);
     assertThat(list.getFirst() != null).isTrue();
     assertThat(list.get(1) != null).isTrue();
@@ -244,7 +244,7 @@ public abstract class UnionBase extends AbstractBaseTest {
     SubQueryExpression<Integer> sq1 = query().from(employee).select(employee.id.max());
     SubQueryExpression<Integer> sq2 = query().from(employee).select(employee.id.min());
 
-    var list = query().union(sq1, sq2).list();
+    var list = query().union(sq1, sq2).fetch();
     assertThat(list).hasSize(2);
     assertThat(list.getFirst() != null).isTrue();
     assertThat(list.get(1) != null).isTrue();
@@ -271,7 +271,7 @@ public abstract class UnionBase extends AbstractBaseTest {
         query().from(employee).select(Projections.constructor(Employee.class, employee.id));
     SubQueryExpression<Employee> sq2 =
         query().from(employee).select(Projections.constructor(Employee.class, employee.id));
-    var employees = query().union(sq1, sq2).list();
+    var employees = query().union(sq1, sq2).fetch();
     for (Employee employee : employees) {
       assertThat(employee).isNotNull();
     }

--- a/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
+++ b/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
@@ -186,7 +186,7 @@ public abstract class AbstractQuerydslProcessor extends AbstractProcessor {
     // track also methods from external entity types
     for (EntityType entityType : new ArrayList<>(typeFactory.getEntityTypes())) {
       var fullName = entityType.getFullName();
-      if (!context.allTypes.keySet().contains(fullName)) {
+      if (!context.allTypes.containsKey(fullName)) {
         var element = processingEnv.getElementUtils().getTypeElement(fullName);
         if (element != null) {
           elementHandler.handleEntityType(element);

--- a/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/ExtendedTypeFactory.java
+++ b/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/ExtendedTypeFactory.java
@@ -434,7 +434,7 @@ public class ExtendedTypeFactory {
     List<? extends TypeMirror> arguments = declaredType.getTypeArguments();
 
     // for intersection types etc
-    if (name.equals("")) {
+    if (name.isEmpty()) {
       var type = objectType;
       if (typeCategory == TypeCategory.COMPARABLE) {
         type = comparableType;

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ECJEvaluatorFactory.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ECJEvaluatorFactory.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.StringTokenizer;
-import java.util.stream.Collectors;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
@@ -141,15 +140,17 @@ public class ECJEvaluatorFactory extends AbstractEvaluatorFactory {
         new INameEnvironment() {
 
           private String join(char[][] compoundName, char separator) {
-            if (compoundName == null) {
-              return "";
-            } else {
-              List<String> parts = new ArrayList<>(compoundName.length);
-              for (char[] part : compoundName) {
-                parts.add(new String(part));
+            if (compoundName == null) return "";
+
+            StringBuilder result = new StringBuilder();
+            for (int i = 0; i < compoundName.length; i++) {
+              result.append(compoundName[i]);
+              if (i < compoundName.length - 1) {
+                result.append(separator);
               }
-              return parts.stream().collect(Collectors.joining(String.valueOf(separator)));
             }
+
+            return result.toString();
           }
 
           @Override

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ECJEvaluatorFactory.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ECJEvaluatorFactory.java
@@ -149,7 +149,6 @@ public class ECJEvaluatorFactory extends AbstractEvaluatorFactory {
                 result.append(separator);
               }
             }
-
             return result.toString();
           }
 

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ECJEvaluatorFactory.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ECJEvaluatorFactory.java
@@ -142,7 +142,7 @@ public class ECJEvaluatorFactory extends AbstractEvaluatorFactory {
           private String join(char[][] compoundName, char separator) {
             if (compoundName == null) return "";
 
-            StringBuilder result = new StringBuilder();
+            var result = new StringBuilder();
             for (int i = 0; i < compoundName.length; i++) {
               result.append(compoundName[i]);
               if (i < compoundName.length - 1) {

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ECJEvaluatorFactory.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ECJEvaluatorFactory.java
@@ -148,7 +148,7 @@ public class ECJEvaluatorFactory extends AbstractEvaluatorFactory {
               for (char[] part : compoundName) {
                 parts.add(new String(part));
               }
-              return parts.stream().collect(Collectors.joining(new String(new char[] {separator})));
+              return parts.stream().collect(Collectors.joining(String.valueOf(separator)));
             }
           }
 

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/SimpleCompiler.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/SimpleCompiler.java
@@ -18,10 +18,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 import javax.lang.model.SourceVersion;
 import javax.tools.DiagnosticListener;
 import javax.tools.JavaCompiler;
@@ -106,9 +103,7 @@ public class SimpleCompiler implements JavaCompiler {
     List<String> args = new ArrayList<>(arguments.length + 2);
     args.add("-classpath");
     args.add(getClasspath());
-    for (String arg : arguments) {
-      args.add(arg);
-    }
-    return compiler.run(in, out, err, args.toArray(new String[args.size()]));
+    args.addAll(Arrays.asList(arguments));
+    return compiler.run(in, out, err, args.toArray(new String[0]));
   }
 }

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/SimpleCompiler.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/SimpleCompiler.java
@@ -104,6 +104,6 @@ public class SimpleCompiler implements JavaCompiler {
     args.add("-classpath");
     args.add(getClasspath());
     args.addAll(Arrays.asList(arguments));
-    return compiler.run(in, out, err, args.toArray(new String[0]));
+    return compiler.run(in, out, err, args.toArray(String[]::new));
   }
 }

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/TypeCategory.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/TypeCategory.java
@@ -76,8 +76,7 @@ public enum TypeCategory {
 
   TypeCategory(TypeCategory superType, String... types) {
     this.superType = superType;
-    this.types = new HashSet<>(types.length);
-    this.types.addAll(Arrays.asList(types));
+    this.types = new HashSet<>(Arrays.asList(types));
   }
 
   public TypeCategory getSuperType() {

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/TypeCategory.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/TypeCategory.java
@@ -13,6 +13,7 @@
  */
 package com.querydsl.codegen.utils.model;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -76,9 +77,7 @@ public enum TypeCategory {
   TypeCategory(TypeCategory superType, String... types) {
     this.superType = superType;
     this.types = new HashSet<>(types.length);
-    for (String type : types) {
-      this.types.add(type);
-    }
+    this.types.addAll(Arrays.asList(types));
   }
 
   public TypeCategory getSuperType() {

--- a/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/ECJEvaluatorFactoryTest.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/ECJEvaluatorFactoryTest.java
@@ -148,8 +148,8 @@ public class ECJEvaluatorFactoryTest {
         factory.createEvaluator(
             "return " + source + ";",
             projectionType,
-            names.toArray(new String[0]),
-            types.toArray(new Class<?>[0]),
+            names.toArray(String[]::new),
+            types.toArray(Class[]::new),
             constants);
     return evaluator.evaluate(args.toArray());
   }

--- a/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/ECJEvaluatorFactoryTest.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/ECJEvaluatorFactoryTest.java
@@ -148,8 +148,8 @@ public class ECJEvaluatorFactoryTest {
         factory.createEvaluator(
             "return " + source + ";",
             projectionType,
-            names.toArray(new String[names.size()]),
-            types.toArray(new Class<?>[types.size()]),
+            names.toArray(new String[0]),
+            types.toArray(new Class<?>[0]),
             constants);
     return evaluator.evaluate(args.toArray());
   }

--- a/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/JDKEvaluatorFactoryTest.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/JDKEvaluatorFactoryTest.java
@@ -148,8 +148,8 @@ public class JDKEvaluatorFactoryTest {
         factory.createEvaluator(
             "return " + source + ";",
             projectionType,
-            names.toArray(new String[0]),
-            types.toArray(new Class<?>[0]),
+            names.toArray(String[]::new),
+            types.toArray(Class[]::new),
             constants);
     return evaluator.evaluate(args.toArray());
   }

--- a/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/JDKEvaluatorFactoryTest.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/JDKEvaluatorFactoryTest.java
@@ -148,8 +148,8 @@ public class JDKEvaluatorFactoryTest {
         factory.createEvaluator(
             "return " + source + ";",
             projectionType,
-            names.toArray(new String[names.size()]),
-            types.toArray(new Class<?>[types.size()]),
+            names.toArray(new String[0]),
+            types.toArray(new Class<?>[0]),
             constants);
     return evaluator.evaluate(args.toArray());
   }

--- a/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java
@@ -54,8 +54,7 @@ public class SimpleCompilerTest {
             "-s",
             "target/out",
             "src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java");
-    var compilationResult =
-        compiler.run(null, null, null, options.toArray(new String[options.size()]));
+    var compilationResult = compiler.run(null, null, null, options.toArray(new String[0]));
     if (compilationResult != 0) {
       fail("Compilation Failed");
     }
@@ -70,8 +69,7 @@ public class SimpleCompilerTest {
     options.add("-s");
     options.add("target/out2");
     options.add("src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java");
-    var compilationResult =
-        compiler.run(null, null, null, options.toArray(new String[options.size()]));
+    var compilationResult = compiler.run(null, null, null, options.toArray(new String[0]));
     if (compilationResult != 0) {
       fail("Compilation Failed");
     }

--- a/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java
@@ -54,7 +54,7 @@ public class SimpleCompilerTest {
             "-s",
             "target/out",
             "src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java");
-    var compilationResult = compiler.run(null, null, null, options.toArray(new String[0]));
+    var compilationResult = compiler.run(null, null, null, options.toArray(String[]::new));
     if (compilationResult != 0) {
       fail("Compilation Failed");
     }
@@ -69,7 +69,7 @@ public class SimpleCompilerTest {
     options.add("-s");
     options.add("target/out2");
     options.add("src/test/java/com/querydsl/codegen/utils/SimpleCompilerTest.java");
-    var compilationResult = compiler.run(null, null, null, options.toArray(new String[0]));
+    var compilationResult = compiler.run(null, null, null, options.toArray(String[]::new));
     if (compilationResult != 0) {
       fail("Compilation Failed");
     }

--- a/querydsl-tooling/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/AbstractNamingStrategy.java
+++ b/querydsl-tooling/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/AbstractNamingStrategy.java
@@ -16,6 +16,7 @@ package com.querydsl.sql.codegen;
 import com.querydsl.codegen.EntityType;
 import com.querydsl.sql.SchemaAndTable;
 import com.querydsl.sql.codegen.support.ForeignKeyData;
+import java.util.regex.Pattern;
 import javax.lang.model.SourceVersion;
 
 /**
@@ -26,6 +27,8 @@ import javax.lang.model.SourceVersion;
  */
 public abstract class AbstractNamingStrategy implements NamingStrategy {
 
+  private static final Pattern PATTERN = Pattern.compile("\r");
+  private static final Pattern REGEX = Pattern.compile("\n");
   protected String foreignKeysClassName = "ForeignKeys";
 
   protected String foreignKeysVariable = "fk";
@@ -97,7 +100,7 @@ public abstract class AbstractNamingStrategy implements NamingStrategy {
 
   protected String normalizeSQLName(String name) {
     if (name != null) {
-      return name.replaceAll("\r", "").replaceAll("\n", " ");
+      return REGEX.matcher(PATTERN.matcher(name).replaceAll("")).replaceAll(" ");
     } else {
       return null;
     }

--- a/querydsl-tooling/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ExtendedBeanSerializer.java
+++ b/querydsl-tooling/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/ExtendedBeanSerializer.java
@@ -144,7 +144,7 @@ public class ExtendedBeanSerializer extends BeanSerializer {
         if (toString.length() > 0) {
           toString.append("+ \";\" + ");
         } else {
-          toString.append("\"" + model.getSimpleName() + "#\" + ");
+          toString.append("\"").append(model.getSimpleName()).append("#\" + ");
         }
         toString.append(propName);
       }

--- a/querydsl-tooling/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
+++ b/querydsl-tooling/querydsl-sql-codegen/src/main/java/com/querydsl/sql/codegen/MetaDataSerializer.java
@@ -266,7 +266,7 @@ public class MetaDataSerializer extends DefaultEntitySerializer {
     for (String javaImport : imports) {
       // true if the character next to the dot is an upper case or if no dot is found (-1+1=0) the
       // first character
-      var isClass = Character.isUpperCase(javaImport.charAt(javaImport.lastIndexOf(".") + 1));
+      var isClass = Character.isUpperCase(javaImport.charAt(javaImport.lastIndexOf('.') + 1));
       if (isClass) {
         classes.add(javaImport);
       } else {


### PR DESCRIPTION
A little bit of cleanup:
-Create Set/List using constructor instead of using constructor and then addAll()
-For toArray(), remove pre-sized arguments
-Fix StringBuilder usage where concatenation is used instead of append()
-Use java.util.Pattern instead of String::replaceAll or String::matches
-Replace deprecated elements: hibernate.save() -> persist(), create ObjectMapper with Builder
-Refactor the "join" method in ECJEvaluatorFactory to improve performance