### PR TITLE
Incremental processing support for ksp

### DIFF
--- a/querydsl-tooling/querydsl-ksp-codegen/pom.xml
+++ b/querydsl-tooling/querydsl-ksp-codegen/pom.xml
@@ -48,6 +48,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.mockk</groupId>
+      <artifactId>mockk-jvm</artifactId>
+      <version>1.13.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-script-runtime</artifactId>
       <scope>test</scope>

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QPropertyType.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QPropertyType.kt
@@ -116,25 +116,26 @@ sealed interface QPropertyType {
     }
 
     class ObjectReference(
-        val target: QueryModel,
+        val entityClassName: ClassName,
+        val queryClassName: ClassName,
         val typeArgs: List<TypeName>
     ) : QPropertyType {
         override val originalClassName: ClassName
-            get() = target.originalClassName
+            get() = entityClassName
 
         override val originalTypeName: TypeName
             get() {
                 if (typeArgs.isEmpty()) {
-                    return target.originalClassName
+                    return entityClassName
                 } else {
-                    return target.originalClassName.parameterizedBy(typeArgs)
+                    return entityClassName.parameterizedBy(typeArgs)
                 }
             }
 
         override val pathClassName: ClassName
-            get() = target.className
+            get() = queryClassName
 
         override val pathTypeName: TypeName
-            get() = target.className
+            get() = queryClassName
     }
 }

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModel.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModel.kt
@@ -1,20 +1,16 @@
 package com.querydsl.ksp.codegen
 
+import com.google.devtools.ksp.symbol.KSFile
 import com.squareup.kotlinpoet.ClassName
 
 class QueryModel(
     val originalClassName: ClassName,
     val typeParameterCount: Int,
     val className: ClassName,
-    val type: Type
+    val type: QueryModelType,
+    val originatingFile: KSFile
 ) {
     var superclass: QueryModel? = null
 
     val properties = mutableListOf<QProperty>()
-
-    enum class Type {
-        ENTITY,
-        EMBEDDABLE,
-        SUPERCLASS
-    }
 }

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelRenderer.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelRenderer.kt
@@ -3,10 +3,9 @@ package com.querydsl.ksp.codegen
 import com.querydsl.core.types.Path
 import com.querydsl.core.types.PathMetadata
 import com.querydsl.core.types.dsl.*
+import com.querydsl.ksp.codegen.Naming.toCamelCase
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.querydsl.ksp.codegen.Naming.toCamelCase
-import java.util.*
 
 object QueryModelRenderer {
     fun render(model: QueryModel): TypeSpec {
@@ -32,9 +31,8 @@ object QueryModelRenderer {
         }
         superclass(
             when (model.type) {
-                QueryModel.Type.ENTITY,
-                QueryModel.Type.SUPERCLASS -> EntityPathBase::class.asClassName().parameterizedBy(constraint)
-                QueryModel.Type.EMBEDDABLE -> BeanPath::class.asClassName().parameterizedBy(constraint)
+                QueryModelType.ENTITY, QueryModelType.SUPERCLASS -> EntityPathBase::class.asClassName().parameterizedBy(constraint)
+                QueryModelType.EMBEDDABLE -> BeanPath::class.asClassName().parameterizedBy(constraint)
             }
         )
         return this
@@ -133,11 +131,11 @@ object QueryModelRenderer {
 
     private fun renderObjectReference(name: String, type: QPropertyType.ObjectReference): PropertySpec {
         return PropertySpec
-            .builder(name, type.target.className)
+            .builder(name, type.queryClassName)
             .delegate(
                 CodeBlock.builder()
                     .beginControlFlow("lazy")
-                    .addStatement("${type.target.className}(forProperty(\"${name}\"))")
+                    .addStatement("${type.queryClassName}(forProperty(\"${name}\"))")
                     .endControlFlow()
                     .build()
             )

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelType.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelType.kt
@@ -1,0 +1,33 @@
+package com.querydsl.ksp.codegen
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.ksp.toTypeName
+import jakarta.persistence.Embeddable
+import jakarta.persistence.Entity
+import jakarta.persistence.MappedSuperclass
+
+enum class QueryModelType(
+    val associatedAnnotation: String
+) {
+    ENTITY(Entity::class.qualifiedName!!),
+    EMBEDDABLE(Embeddable::class.qualifiedName!!),
+    SUPERCLASS(MappedSuperclass::class.qualifiedName!!);
+
+    companion object {
+        fun autodetect(classDeclaration: KSClassDeclaration): QueryModelType? {
+            for (annotation in classDeclaration.annotations) {
+                for (type in QueryModelType.entries) {
+                    if (annotation.isEqualTo(type.associatedAnnotation)) {
+                        return type
+                    }
+                }
+            }
+            return null
+        }
+
+        private fun KSAnnotation.isEqualTo(annotationQualifiedName: String): Boolean {
+            return annotationType.toTypeName().toString() == annotationQualifiedName
+        }
+    }
+}

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/SimpleType.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/SimpleType.kt
@@ -95,7 +95,7 @@ sealed interface SimpleType {
         override fun render(name: String): PropertySpec {
             return PropertySpec
                 .builder(name, pathTypeName)
-                .initializer("createNumber(\"$name\", ${innerType}::class.java)")
+                .initializer("createNumber(\"$name\", ${innerType}::class.javaObjectType)")
                 .build()
         }
     }

--- a/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/RenderTest.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/RenderTest.kt
@@ -3,9 +3,11 @@ import com.querydsl.ksp.codegen.QProperty
 import com.querydsl.ksp.codegen.QPropertyType
 import com.querydsl.ksp.codegen.QueryModel
 import com.querydsl.ksp.codegen.QueryModelRenderer
+import com.querydsl.ksp.codegen.QueryModelType
 import com.querydsl.ksp.codegen.SimpleType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.asClassName
+import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import javax.script.ScriptEngineManager
@@ -17,7 +19,8 @@ class RenderTest {
             originalClassName = ClassName("", "User"),
             typeParameterCount = 0,
             className = ClassName("", "QUser"),
-            type = QueryModel.Type.ENTITY
+            type = QueryModelType.ENTITY,
+            mockk()
         )
         val properties = listOf(
             QProperty("a", QPropertyType.Simple(SimpleType.QBoolean)),
@@ -51,13 +54,15 @@ class RenderTest {
             originalClassName = ClassName("", "Cat"),
             typeParameterCount = 0,
             className = ClassName("", "QCat"),
-            type = QueryModel.Type.ENTITY
+            type = QueryModelType.ENTITY,
+            mockk()
         )
         val superClass = QueryModel(
             originalClassName = ClassName("", "Animal"),
             typeParameterCount = 0,
             className = ClassName("", "QAnimal"),
-            type = QueryModel.Type.SUPERCLASS
+            type = QueryModelType.SUPERCLASS,
+            mockk()
         )
         model.superclass = superClass
         val typeSpec = QueryModelRenderer.render(model)
@@ -73,7 +78,8 @@ class RenderTest {
             originalClassName = ClassName("", "Article"),
             typeParameterCount = 1,
             className = ClassName("", "QArticle"),
-            type = QueryModel.Type.ENTITY
+            type = QueryModelType.ENTITY,
+            mockk()
         )
         val typeSpec = QueryModelRenderer.render(model)
         val code = typeSpec.toString()
@@ -102,7 +108,8 @@ class RenderTest {
             originalClassName = ClassName("", "Animal"),
             typeParameterCount = 0,
             className = ClassName("", "QAnimal"),
-            type = QueryModel.Type.ENTITY
+            type = QueryModelType.ENTITY,
+            mockk()
         )
         animalModel.properties.add(
             QProperty("hasTail", QPropertyType.Simple(SimpleType.QBoolean))
@@ -111,7 +118,8 @@ class RenderTest {
             originalClassName = ClassName("", "Cat"),
             typeParameterCount = 0,
             className = ClassName("", "QCat"),
-            type = QueryModel.Type.ENTITY
+            type = QueryModelType.ENTITY,
+            mockk()
         )
         catModel.superclass = animalModel
         val typeSpec = QueryModelRenderer.render(catModel)
@@ -126,7 +134,8 @@ class RenderTest {
             originalClassName = ClassName("", "Animal"),
             typeParameterCount = 0,
             className = ClassName("", "QAnimal"),
-            type = QueryModel.Type.ENTITY
+            type = QueryModelType.ENTITY,
+            mockk()
         )
         model.properties.add(
             QProperty(


### PR DESCRIPTION
As mentioned these are the changes.
Fixing incremental processing support required some larger changes.

Also includes fix for as crash that would happen when using NumberPath with Kotlin types in certain operations during a query.

The test code needed some way to reference KSFile objects, although these are actually not used in the generation itself but must be linked sothat KSP knows when to reprocess the file.

I used mockk to represent these objects in the code, it's a common Kotlin library for mocks.
Not sure if you would have preferred for  me to use some other java library for this?