### PR TITLE
Kotlin KSP Nullability Fix

### DIFF
--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Cat.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Cat.kt
@@ -1,12 +1,22 @@
 package com.querydsl.example.ksp
 
 import jakarta.persistence.Entity
+import jakarta.persistence.Enumerated
+import jakarta.persistence.EnumType
 import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
 
 @Entity
 class Cat(
     @Id
     val id: Int,
     val name: String,
-    val isTailUpright: Boolean
+    val isTailUpright: Boolean,
+    val fluffiness: String? = null,
+
+    @ManyToOne
+    val owner: Person? = null,
+
+    @Enumerated(EnumType.STRING)
+    val catType: CatType? = CatType.HOUSE,
 )

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/CatType.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/CatType.kt
@@ -1,0 +1,6 @@
+package com.querydsl.example.ksp
+
+enum class CatType {
+    HOUSE,
+    MAINE_COON
+}

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Person.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Person.kt
@@ -2,10 +2,14 @@ package com.querydsl.example.ksp
 
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
 
 @Entity
 class Person(
     @Id
     val id: Int,
     val name: String,
+
+    @OneToMany(mappedBy = "owner")
+    val cats: List<Cat>? = null,
 )


### PR DESCRIPTION
When using nullable types in JPA Entity fields, the type determination code was throwing exceptions. This change creates a local version of the KSType.toClassName() function which gets the ClassName while ignoring the KSType's nullability and parameterization. It also ensures that the ClassName returned does not include a nullability modifier as it previously did with Enums.