### PR TITLE
Fix NPE in ksp processing (#862)

### DIFF
--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryDslProcessor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryDslProcessor.kt
@@ -36,7 +36,7 @@ class QueryDslProcessor(
                 .writeTo(
                     codeGenerator = codeGenerator,
                     aggregating = false,
-                    originatingKSFiles = listOf(model.originatingFile)
+                    originatingKSFiles = listOfNotNull(model.originatingFile)
                 )
         }
     }

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryDslProcessor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryDslProcessor.kt
@@ -1,6 +1,7 @@
 package com.querydsl.ksp.codegen
 
 import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.*
@@ -12,8 +13,10 @@ class QueryDslProcessor(
     private val codeGenerator: CodeGenerator
 ) : SymbolProcessor {
     val typeProcessor = QueryModelExtractor(settings)
+    lateinit var typeResolver: Resolver
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
+        typeResolver = resolver
         if (settings.enable) {
             QueryModelType.entries.forEach { type ->
                 resolver.getSymbolsWithAnnotation(type.associatedAnnotation)
@@ -29,14 +32,22 @@ class QueryDslProcessor(
         val models = typeProcessor.process()
         models.forEach { model ->
             val typeSpec = QueryModelRenderer.render(model)
+
+            val sources = if (model.originatingFile != null) {
+                arrayOf(model.originatingFile)
+            } else if (this::typeResolver.isInitialized) {
+                typeResolver.getAllFiles().toList().toTypedArray()
+            } else {
+                emptyArray()
+            }
+
             FileSpec.builder(model.className)
                 .indent(settings.indent)
                 .addType(typeSpec)
                 .build()
                 .writeTo(
-                    codeGenerator = codeGenerator,
-                    aggregating = false,
-                    originatingKSFiles = listOfNotNull(model.originatingFile)
+                    codeGenerator,
+                    Dependencies(false, *sources)
                 )
         }
     }

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModel.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModel.kt
@@ -8,7 +8,7 @@ class QueryModel(
     val typeParameterCount: Int,
     val className: ClassName,
     val type: QueryModelType,
-    val originatingFile: KSFile
+    val originatingFile: KSFile?
 ) {
     var superclass: QueryModel? = null
 

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelExtractor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelExtractor.kt
@@ -112,7 +112,7 @@ class QueryModelExtractor(
             typeParameterCount = classDeclaration.typeParameters.size,
             className = queryClassName(classDeclaration, settings),
             type = type,
-            originatingFile = classDeclaration.containingFile!!
+            originatingFile = classDeclaration.containingFile
         )
     }
 

--- a/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/RenderTest.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/RenderTest.kt
@@ -73,6 +73,30 @@ class RenderTest {
     }
 
     @Test
+    fun superclassNullContainingFile() {
+        val model = QueryModel(
+            originalClassName = ClassName("", "Cat"),
+            typeParameterCount = 0,
+            className = ClassName("", "QCat"),
+            type = QueryModelType.ENTITY,
+            mockk()
+        )
+        val superClass = QueryModel(
+            originalClassName = ClassName("", "Animal"),
+            typeParameterCount = 0,
+            className = ClassName("", "QAnimal"),
+            type = QueryModelType.SUPERCLASS,
+            null
+        )
+        model.superclass = superClass
+        val typeSpec = QueryModelRenderer.render(model)
+        val code = typeSpec.toString()
+        code.assertCompiles()
+        code.assertContains("class QCat : com.querydsl.core.types.dsl.EntityPathBase<Cat>")
+        code.assertContainLines("val _super: QAnimal by lazy { QAnimal(this) }")
+    }
+
+    @Test
     fun genericTypeArgs() {
         val model = QueryModel(
             originalClassName = ClassName("", "Article"),


### PR DESCRIPTION
### Overview
The `containingFile` of `KSClassDeclaration` is nullable. Update the processing to handle a null containingFile. 

I was able to pull, modify, and build the project artifacts. This change fixes the NullPointerException (my local project build now fully completes) and I am able to see the generated Q entities from the external library. Both my Child class entity and Parent Entity in the external library are generated. 

### Testing
Run build to completion (`mvn -Pquickbuild,all clean install`), pulled in artifacts to my project, built & ran without issues. 

### Note
Please let me know if `master` is the correct branch to get a quick fix out. Thanks!