### PR TITLE
Fix file generation issue on rebuild (#862)

### DIFF
--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryDslProcessor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryDslProcessor.kt
@@ -28,6 +28,13 @@ class QueryDslProcessor(
     override fun finish() {
         val models = typeProcessor.process()
         models.forEach { model ->
+            if (model.originatingFile == null) {
+                // skip models without originating file. This happens when the model is from a compiled dependency,
+                // so we don't have access to the source file. It is expected the Q class is packaged alongside the
+                // compiled dependency.
+                return@forEach
+            }
+
             val typeSpec = QueryModelRenderer.render(model)
             FileSpec.builder(model.className)
                 .indent(settings.indent)
@@ -36,7 +43,7 @@ class QueryDslProcessor(
                 .writeTo(
                     codeGenerator = codeGenerator,
                     aggregating = false,
-                    originatingKSFiles = listOfNotNull(model.originatingFile)
+                    originatingKSFiles = listOf(model.originatingFile)
                 )
         }
     }


### PR DESCRIPTION
### Overview
- Follow up on @IceBlizz6 comment from PR https://github.com/OpenFeign/querydsl/pull/865 

Alot of details in the comments of that PR, but after the NPE from #862 was fixed an additional cross-project rebuild issue was introduced now that the build is getting through the NPE. This was not related to the NPE fix, but as far as I can tell it is just a lacking feature in querydsl ksp processing. 

The change moves responsibilities of generating Q classes to each individual module, whether that module is in a local project or a library dependency. If a module is expecting a class (like a base entity `@MappedSuperclass`) to be used in a client project, it must incorporate KSP processing and package the generated Q class in its artifact. To achieve this, the superclasses are still stored as a `QueryModel`, but the files are not written if the `containingFile` is null.

### Testing
Local project (and 2 test projects from the original ticket) were updated with this change and ran all Q class generation successfully for every build

