### PR TITLE
feat(@QueryProjection): support builder-based Q class generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,14 @@
         <version>0.23.1</version>
         <configuration>
           <parameter>
+            <excludes>
+              <exclude>com.querydsl.core.annotations.QueryProjection</exclude>
+              <exclude>com.querydsl.codegen.utils.AbstractCodeWriter</exclude>
+              <exclude>com.querydsl.codegen.utils.CodeWriter#beginInnerStaticClass(com.querydsl.codegen.utils.model.Type,com.querydsl.codegen.utils.model.Type,com.querydsl.codegen.utils.model.Type[])#</exclude>
+              <exclude>com.querydsl.codegen.utils.CodeWriter#beginInnerStaticClass(com.querydsl.codegen.utils.model.Type)</exclude>
+              <exclude>com.querydsl.apt.TypeElementHandler#handleEntityType(javax.lang.model.element.TypeElement)</exclude>
+              <exclude>com.querydsl.apt.TypeElementHandler#handleProjectionType(javax.lang.model.element.TypeElement,boolean)</exclude>
+            </excludes>
             <ignoreMissingOldVersion>true</ignoreMissingOldVersion>
             <onlyModified>true</onlyModified>
             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>

--- a/pom.xml
+++ b/pom.xml
@@ -453,12 +453,7 @@
         <configuration>
           <parameter>
             <excludes>
-              <exclude>com.querydsl.core.annotations.QueryProjection</exclude>
-              <exclude>com.querydsl.codegen.utils.AbstractCodeWriter</exclude>
-              <exclude>com.querydsl.codegen.utils.CodeWriter#beginInnerStaticClass(com.querydsl.codegen.utils.model.Type,com.querydsl.codegen.utils.model.Type,com.querydsl.codegen.utils.model.Type[])#</exclude>
-              <exclude>com.querydsl.codegen.utils.CodeWriter#beginInnerStaticClass(com.querydsl.codegen.utils.model.Type)</exclude>
-              <exclude>com.querydsl.apt.TypeElementHandler#handleEntityType(javax.lang.model.element.TypeElement)</exclude>
-              <exclude>com.querydsl.apt.TypeElementHandler#handleProjectionType(javax.lang.model.element.TypeElement,boolean)</exclude>
+              <exclude>com.querydsl.core.annotations.QueryProjection</exclude>          
             </excludes>
             <ignoreMissingOldVersion>true</ignoreMissingOldVersion>
             <onlyModified>true</onlyModified>

--- a/pom.xml
+++ b/pom.xml
@@ -473,14 +473,6 @@
             <accessModifier>public</accessModifier>
           </parameter>
         </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>cmp</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/querydsl-libraries/pom.xml
+++ b/querydsl-libraries/pom.xml
@@ -138,6 +138,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>cmp</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/annotations/QueryProjection.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/annotations/QueryProjection.java
@@ -53,4 +53,9 @@ import java.lang.annotation.Target;
 @Documented
 @Target({ElementType.CONSTRUCTOR, ElementType.TYPE})
 @Retention(RUNTIME)
-public @interface QueryProjection {}
+public @interface QueryProjection {
+
+  boolean useBuilder() default false;
+
+  String builderName() default "";
+}

--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/annotations/QueryProjection.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/annotations/QueryProjection.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  *
  *     private String firstName, lastName;
  *
- *     {@code @QueryProjection}
+ *     {@code @QueryProjection(useBuilder = true, builderName = "new")}
  *     public UserInfo(String firstName, String lastName) {
  *         this.firstName = firstName;
  *         this.lastName = lastName;
@@ -47,6 +47,20 @@ import java.lang.annotation.Target;
  * List <UserInfo> result = querydsl.from(user)
  *     .where(user.valid.eq(true))
  *     .select(new QUserInfo(user.firstName, user.lastName))
+ *     .fetch();
+ * }</pre>
+ *
+ * or(with Builder)
+ *
+ * <pre>{@code
+ * QUser user = QUser.user;
+ * List <UserInfo> result = querydsl.from(user)
+ *     .where(user.valid.eq(true))
+ *     .select(QUserInfo.builderNew()
+ *            .firstName(user.firstName)
+ *            .lastName(user.lastName)
+ *            .build()
+ *     )
  *     .fetch();
  * }</pre>
  */

--- a/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/TypeElementHandler.java
+++ b/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/TypeElementHandler.java
@@ -206,6 +206,7 @@ public class TypeElementHandler {
       List<? extends Element> elements,
       boolean onlyAnnotatedConstructors,
       Messager messager) {
+    var builderNameSet = new HashSet<String>();
     for (ExecutableElement constructor : ElementFilter.constructorsIn(elements)) {
       if (configuration.isValidConstructor(constructor, onlyAnnotatedConstructors)) {
         var parameters = transformParams(constructor.getParameters());
@@ -219,10 +220,20 @@ public class TypeElementHandler {
               constructor);
           return;
         }
+
         Constructor constructorModel = new Constructor(parameters);
         constructorModel.setUseBuilder(projection != null && projection.useBuilder());
         constructorModel.setBuilderName(projection != null ? projection.builderName() : "");
 
+        if (builderNameSet.contains(constructorModel.getBuilderName())) {
+          messager.printMessage(
+              Diagnostic.Kind.ERROR,
+              "Duplicate builderName found: " + constructorModel.getBuilderName(),
+              constructor);
+          return;
+        }
+
+        builderNameSet.add(constructorModel.getBuilderName());
         entityType.addConstructor(constructorModel);
       }
     }

--- a/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/TypeElementHandler.java
+++ b/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/TypeElementHandler.java
@@ -225,7 +225,8 @@ public class TypeElementHandler {
         constructorModel.setUseBuilder(projection != null && projection.useBuilder());
         constructorModel.setBuilderName(projection != null ? projection.builderName() : "");
 
-        if (builderNameSet.contains(constructorModel.getBuilderName())) {
+        if (constructorModel.useBuilder()
+            && builderNameSet.contains(constructorModel.getBuilderName())) {
           messager.printMessage(
               Diagnostic.Kind.ERROR,
               "Duplicate builderName found: " + constructorModel.getBuilderName(),

--- a/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/GenericExporterTest.java
+++ b/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/GenericExporterTest.java
@@ -50,6 +50,7 @@ public class GenericExporterTest extends AbstractProcessorTest {
     expected.add("QQueryProjectionTest_EntityWithProjection.java");
     expected.add("QEmbeddable3Test_EmbeddableClass.java");
     expected.add("QQueryEmbedded4Test_User.java");
+    expected.add("QQueryProjectionBuilderTestEntity.java");
 
     execute(expected, "GenericExporterTest", "QuerydslAnnotationProcessor");
   }
@@ -89,6 +90,7 @@ public class GenericExporterTest extends AbstractProcessorTest {
     expected.add("QOneToOneTest_Person.java");
     expected.add("QGeneric16Test_HidaBez.java");
     expected.add("QGeneric16Test_HidaBezGruppe.java");
+    expected.add("QQueryProjectionBuilderTestEntity.java");
 
     execute(expected, "GenericExporterTest2", "HibernateAnnotationProcessor");
   }

--- a/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/domain/QueryProjectionBuilderTest.java
+++ b/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/domain/QueryProjectionBuilderTest.java
@@ -1,0 +1,34 @@
+package com.querydsl.apt.domain;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.querydsl.core.types.dsl.Expressions;
+import org.junit.Test;
+
+public class QueryProjectionBuilderTest {
+
+  @Test
+  public void builder_buildsQClassCorrectly() {
+    var property = Expressions.stringPath("x");
+    QQueryProjectionBuilderTestEntity dto =
+        QQueryProjectionBuilderTestEntity.builderTest1().setProperty(property).build();
+
+    assertNotNull(dto);
+    assertEquals(QueryProjectionBuilderTestEntity.class, dto.getType());
+  }
+
+  @Test
+  public void builder_buildsQClassCorrectly2() {
+    var property = Expressions.stringPath("x");
+    var intProperty = Expressions.numberPath(Integer.class, "y");
+    QQueryProjectionBuilderTestEntity dto =
+        QQueryProjectionBuilderTestEntity.builderTest2()
+            .setProperty(property)
+            .setIntProperty(intProperty)
+            .build();
+
+    assertNotNull(dto);
+    assertEquals(QueryProjectionBuilderTestEntity.class, dto.getType());
+  }
+}

--- a/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/domain/QueryProjectionBuilderTestEntity.java
+++ b/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/domain/QueryProjectionBuilderTestEntity.java
@@ -1,0 +1,32 @@
+package com.querydsl.apt.domain;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public class QueryProjectionBuilderTestEntity {
+  private String property;
+  private int intProperty;
+  private Test test;
+
+  @QueryProjection(useBuilder = true, builderName = "Test1")
+  public QueryProjectionBuilderTestEntity(String property) {
+    this.property = property;
+  }
+
+  @QueryProjection(useBuilder = true, builderName = "Test2")
+  public QueryProjectionBuilderTestEntity(String property, int intProperty) {
+    this.property = property;
+    this.intProperty = intProperty;
+  }
+
+  @QueryProjection(useBuilder = true, builderName = "Test3")
+  public QueryProjectionBuilderTestEntity(String property, int intProperty, Test test) {
+    this.property = property;
+    this.intProperty = intProperty;
+    this.test = test;
+  }
+
+  public static class Test {
+    private String property;
+    private int intProperty;
+  }
+}

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/CodeWriter.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/CodeWriter.java
@@ -41,6 +41,11 @@ public interface CodeWriter extends Appendable {
 
   CodeWriter beginClass(Type type, Type superClass, Type... interfaces) throws IOException;
 
+  CodeWriter beginInnerStaticClass(Type type) throws IOException;
+
+  CodeWriter beginInnerStaticClass(Type type, Type superClass, Type... interfaces)
+      throws IOException;
+
   <T> CodeWriter beginConstructor(Collection<T> params, Function<T, Parameter> transformer)
       throws IOException;
 

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/JavaWriter.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/JavaWriter.java
@@ -57,6 +57,8 @@ public final class JavaWriter extends AbstractCodeWriter<JavaWriter> {
 
   private static final String PUBLIC_CLASS = "public class ";
 
+  private static final String PUBLIC_STATIC_CLASS = "public static class ";
+
   private static final String PUBLIC_FINAL = "public final ";
 
   private static final String PUBLIC_INTERFACE = "public interface ";
@@ -190,6 +192,33 @@ public final class JavaWriter extends AbstractCodeWriter<JavaWriter> {
     if (interfaces.length > 0) {
       append(IMPLEMENTS);
       for (var i = 0; i < interfaces.length; i++) {
+        if (i > 0) {
+          append(Symbols.COMMA);
+        }
+        append(interfaces[i].getGenericName(false, packages, classes));
+      }
+    }
+    append(" {").nl().nl();
+    goIn();
+    types.push(type);
+    return this;
+  }
+
+  @Override
+  public CodeWriter beginInnerStaticClass(Type type) throws IOException {
+    return beginInnerStaticClass(type, null);
+  }
+
+  @Override
+  public CodeWriter beginInnerStaticClass(Type type, Type superClass, Type... interfaces)
+      throws IOException {
+    beginLine(PUBLIC_STATIC_CLASS, type.getGenericName(false, packages, classes));
+    if (superClass != null) {
+      append(EXTENDS).append(superClass.getGenericName(false, packages, classes));
+    }
+    if (interfaces.length > 0) {
+      append(IMPLEMENTS);
+      for (int i = 0; i < interfaces.length; i++) {
         if (i > 0) {
           append(Symbols.COMMA);
         }

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ScalaWriter.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/ScalaWriter.java
@@ -254,6 +254,16 @@ public class ScalaWriter extends AbstractCodeWriter<ScalaWriter> {
   }
 
   @Override
+  public CodeWriter beginInnerStaticClass(Type type) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public CodeWriter beginInnerStaticClass(Type type, Type superClass, Type... interfaces) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
   public <T> ScalaWriter beginConstructor(
       Collection<T> parameters, Function<T, Parameter> transformer) throws IOException {
     beginLine(DEF, THIS).params(parameters, transformer).append(" {").nl();

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/Constructor.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/model/Constructor.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 public final class Constructor implements Comparable<Constructor> {
 
   private final Collection<Parameter> parameters;
+  private boolean useBuilder = false;
+  private String builderName = "";
 
   public Constructor(Collection<Parameter> params) {
     parameters = params;
@@ -39,6 +41,22 @@ public final class Constructor implements Comparable<Constructor> {
 
   public Collection<Parameter> getParameters() {
     return parameters;
+  }
+
+  public boolean useBuilder() {
+    return useBuilder;
+  }
+
+  public void setUseBuilder(boolean useBuilder) {
+    this.useBuilder = useBuilder;
+  }
+
+  public String getBuilderName() {
+    return builderName;
+  }
+
+  public void setBuilderName(String builderName) {
+    this.builderName = builderName;
   }
 
   @Override

--- a/querydsl-tooling/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
+++ b/querydsl-tooling/querydsl-codegen/src/main/java/com/querydsl/codegen/GenericExporter.java
@@ -403,7 +403,11 @@ public class GenericExporter {
           }
           parameters.add(new Parameter("param" + i, parameterType));
         }
-        type.addConstructor(new com.querydsl.codegen.utils.model.Constructor(parameters));
+        var queryProjection = constructor.getAnnotation(QueryProjection.class);
+        var newConstructor = new com.querydsl.codegen.utils.model.Constructor(parameters);
+        newConstructor.setUseBuilder(queryProjection.useBuilder());
+        newConstructor.setBuilderName(queryProjection.builderName());
+        type.addConstructor(newConstructor);
       }
     }
   }


### PR DESCRIPTION
## Multi-builder Support

- You can now define multiple `@QueryProjection(useBuilder = true, builderName = "...")` constructors per DTO.
- Each builder will be uniquely named inside the Q class and exposed via static factory methods.
- Advantages of { concise syntax, no explicit `new`,  IDE friendly}
### Highlights
1. Fully backward compatible — default remains constructor-style
2. No need to manually define a builder in the DTO
3. Improves readability and safety in complex DTO projections
4. All builder method arguments are Expression<?>, just like in constructor-style projections

#### Required `builderName` when `useBuilder = true`

To support multiple builder configurations, `@QueryProjection(useBuilder = true)` now requires a non-empty `builderName`.  
This helps prevent name collisions when generating builder classes and factory methods.

#### Example

```java
public class QueryProjectionBuilderTestEntity {
  private String property;
  private int intProperty;
  private Test test;

  @QueryProjection(useBuilder = true, builderName = "Test1")
  public QueryProjectionBuilderTestEntity(String property) {
    this.property = property;
  }

  @QueryProjection(useBuilder = true, builderName = "Test2")
  public QueryProjectionBuilderTestEntity(String property, int intProperty) {
    this.property = property;
    this.intProperty = intProperty;
  }

  @QueryProjection(useBuilder = true, builderName = "Test3")
  public QueryProjectionBuilderTestEntity(String property, int intProperty, Test test) {
    this.property = property;
    this.intProperty = intProperty;
    this.test = test;
  }

  public static class Test {
    private String property;
    private int intProperty;
  }
```


and generated QClass is below 
```java
/**
 * com.querydsl.apt.domain.QQueryProjectionBuilderTestEntity is a Querydsl Projection type for QueryProjectionBuilderTestEntity
 */
@SuppressWarnings("this-escape")
@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
public class QQueryProjectionBuilderTestEntity extends ConstructorExpression<QueryProjectionBuilderTestEntity> {

    private static final long serialVersionUID = 264670126L;

    public QQueryProjectionBuilderTestEntity(com.querydsl.core.types.Expression<String> property) {
        super(QueryProjectionBuilderTestEntity.class, new Class<?>[]{String.class}, property);
    }

    public QQueryProjectionBuilderTestEntity(com.querydsl.core.types.Expression<String> property, com.querydsl.core.types.Expression<Integer> intProperty) {
        super(QueryProjectionBuilderTestEntity.class, new Class<?>[]{String.class, int.class}, property, intProperty);
    }

    public QQueryProjectionBuilderTestEntity(com.querydsl.core.types.Expression<String> property, com.querydsl.core.types.Expression<Integer> intProperty, com.querydsl.core.types.Expression<? extends QueryProjectionBuilderTestEntity.Test> test) {
        super(QueryProjectionBuilderTestEntity.class, new Class<?>[]{String.class, int.class, QueryProjectionBuilderTestEntity.Test.class}, property, intProperty, test);
    }

    public static class Test1Builder {

        private com.querydsl.core.types.Expression<String> property;

        public Test1Builder setProperty(com.querydsl.core.types.Expression<String> property) {
            this.property = property;
            return this;
        }

        public QQueryProjectionBuilderTestEntity build() {
            return new QQueryProjectionBuilderTestEntity(property);
        }

    }

    public static Test1Builder builderTest1() {
        return new Test1Builder();
    }

    public static class Test2Builder {

        private com.querydsl.core.types.Expression<String> property;

        private com.querydsl.core.types.Expression<Integer> intProperty;

        public Test2Builder setProperty(com.querydsl.core.types.Expression<String> property) {
            this.property = property;
            return this;
        }

        public Test2Builder setIntProperty(com.querydsl.core.types.Expression<Integer> intProperty) {
            this.intProperty = intProperty;
            return this;
        }

        public QQueryProjectionBuilderTestEntity build() {
            return new QQueryProjectionBuilderTestEntity(property, intProperty);
        }

    }

    public static Test2Builder builderTest2() {
        return new Test2Builder();
    }

    public static class Test3Builder {

        private com.querydsl.core.types.Expression<String> property;

        private com.querydsl.core.types.Expression<Integer> intProperty;

        private com.querydsl.core.types.Expression<? extends QueryProjectionBuilderTestEntity.Test> test;

        public Test3Builder setProperty(com.querydsl.core.types.Expression<String> property) {
            this.property = property;
            return this;
        }

        public Test3Builder setIntProperty(com.querydsl.core.types.Expression<Integer> intProperty) {
            this.intProperty = intProperty;
            return this;
        }

        public Test3Builder setTest(com.querydsl.core.types.Expression<? extends QueryProjectionBuilderTestEntity.Test> test) {
            this.test = test;
            return this;
        }

        public QQueryProjectionBuilderTestEntity build() {
            return new QQueryProjectionBuilderTestEntity(property, intProperty, test);
        }

    }

    public static Test3Builder builderTest3() {
        return new Test3Builder();
    }

}
```


### Question 
[this commit](https://github.com/OpenFeign/querydsl/pull/1078/commits/c8faebabf696ec893ebd806f8bada1eaa3b21d2b) 
 
I don't want to update pom.xml of root, how can I resolve binary incompatible problem
