### PR TITLE
querydsl-ksp-codegen: Support @JdbcTypeCode in KSP code generation

### DIFF
--- a/querydsl-examples/querydsl-example-ksp-codegen/build.gradle.kts
+++ b/querydsl-examples/querydsl-example-ksp-codegen/build.gradle.kts
@@ -6,25 +6,26 @@ val querydslVersion = findProperty("querydsl.version") as String
 val assertjVersion = findProperty("assertj.version") as String
 
 plugins {
-	kotlin("jvm")
-	id("com.google.devtools.ksp")
-	kotlin("plugin.jpa")
-	kotlin("plugin.serialization")
+        kotlin("jvm")
+        id("com.google.devtools.ksp")
+        kotlin("plugin.jpa")
+        kotlin("plugin.serialization")
 }
 
 repositories {
-	mavenCentral()
-	mavenLocal()
+        mavenCentral()
+        mavenLocal()
 }
 
 dependencies {
-	implementation("jakarta.persistence:jakarta.persistence-api:${jpaVersion}")
-	implementation("io.github.openfeign.querydsl:querydsl-core:${querydslVersion}")
-	ksp("io.github.openfeign.querydsl:querydsl-ksp-codegen:${querydslVersion}")
-
-	testImplementation("io.github.openfeign.querydsl:querydsl-jpa:${querydslVersion}")
-	testImplementation("org.assertj:assertj-core:${assertjVersion}")
-	testImplementation("org.hibernate.orm:hibernate-core:${hibernateVersion}")
-	testImplementation("com.h2database:h2:${h2Version}")
-	testImplementation("org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion}")
+        implementation("jakarta.persistence:jakarta.persistence-api:${jpaVersion}")
+        implementation("io.github.openfeign.querydsl:querydsl-core:${querydslVersion}")
+        implementation("org.hibernate.orm:hibernate-core:${hibernateVersion}")
+        ksp("io.github.openfeign.querydsl:querydsl-ksp-codegen:${querydslVersion}")
+        implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.19.0")
+        testImplementation("io.github.openfeign.querydsl:querydsl-jpa:${querydslVersion}")
+        testImplementation("org.assertj:assertj-core:${assertjVersion}")
+        testImplementation("org.hibernate.orm:hibernate-core:${hibernateVersion}")
+        testImplementation("com.h2database:h2:${h2Version}")
+        testImplementation("org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion}")
 }

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Dog.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Dog.kt
@@ -1,0 +1,17 @@
+package com.querydsl.example.ksp
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+
+@Entity
+class Dog(
+    @Id
+    val id: Int,
+    val name: String,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    val tag: Tag
+)

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Tag.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Tag.kt
@@ -1,0 +1,6 @@
+package com.querydsl.example.ksp
+
+class Tag(
+    val id: Int,
+    val name: String,
+)

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/TypeExtractor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/TypeExtractor.kt
@@ -112,6 +112,7 @@ class TypeExtractor(
     private fun userType(type: KSType): QPropertyType.Unknown? {
         val userTypeAnnotations = listOf(
             ClassName("org.hibernate.annotations", "Type"),
+            ClassName("org.hibernate.annotations", "JdbcTypeCode"),
             Convert::class.asClassName()
         )
         if (property.annotations.any { userTypeAnnotations.contains(it.annotationType.resolve().toClassName()) }) {


### PR DESCRIPTION
### Background and Problem
Starting from Hibernate 6, the @JdbcTypeCode annotation allows developers to explicitly specify the JDBC type for entity fields. 

For example :
```kotlin
@JdbcTypeCode(SqlTypes.JSON)
@Column(columnDefinition = "json")
val tag: Tag
```
However, the current implementation of querydsl-ksp-codegen does not recognize this annotation. When an entity field is annotated with @JdbcTypeCode, the code generator throws an exception and **fails the entire Q-class generation** at compile time

```
IllegalStateException: Type was not recognised, This may be an entity that has not been annotated with @Entity, or maybe you are using javax instead of jakarta.
```
This is not just a misclassification — the code generation fails entirely, making the project unbuildable if such annotations are present.

### Changes Introduced
- Fields annotated with `@JdbcTypeCode` are now recognized and internally treated as `QPropertyType.Unknown.`

- This change ensures that code generation does not fail; instead, such fields are safely handled as user-defined types and mapped to a valid Querydsl path type.

### Testing
Due to the nature of KSP (which operates at compile-time), it is difficult to verify this behavior via unit tests using `kotlin-compile-testing` directly within the `querydsl-ksp-codegen` module.

Instead, I added test entities using `@JdbcTypeCode` in the `querydsl-example-ksp-codegen` module and confirmed that:

- The `Q` class is generated successfully.

- The annotated field does not block code generation.

- The field appears as a `SimplePath` in the output, preserving type safety.