### PR TITLE
Fix: Improve handling of `contains()` on JPA collections mapped with `@Converter` to basic types

### DIFF
--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
@@ -634,11 +634,7 @@ public class JPQLSerializer extends SerializerBase<JPQLSerializer> {
       }
     }
     super.visitOperation(
-        type,
-        (operator == Ops.IN
-            ? com.querydsl.jpa.JPQLOps.MEMBER_OF
-            : com.querydsl.jpa.JPQLOps.NOT_MEMBER_OF),
-        args);
+        type, operator == Ops.IN ? JPQLOps.MEMBER_OF : JPQLOps.NOT_MEMBER_OF, args);
   }
 
   @SuppressWarnings("unchecked")

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
@@ -17,28 +17,14 @@ import com.querydsl.core.JoinExpression;
 import com.querydsl.core.JoinType;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.support.SerializerBase;
-import com.querydsl.core.types.CollectionExpression;
-import com.querydsl.core.types.Constant;
-import com.querydsl.core.types.ConstantImpl;
-import com.querydsl.core.types.EntityPath;
-import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.ExpressionUtils;
-import com.querydsl.core.types.FactoryExpression;
-import com.querydsl.core.types.MapExpression;
-import com.querydsl.core.types.Operation;
-import com.querydsl.core.types.Operator;
-import com.querydsl.core.types.Ops;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Path;
-import com.querydsl.core.types.PathType;
-import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.util.MathUtils;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.Metamodel;
 import jakarta.persistence.metamodel.SingularAttribute;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -596,10 +582,63 @@ public class JPQLSerializer extends SerializerBase<JPQLSerializer> {
     return null;
   }
 
+  private boolean isCollectionPathWithConverterToBasicType(Path<?> path, Metamodel metamodel) {
+
+    PathMetadata metadata = path.getMetadata();
+    if (metadata.getPathType() != PathType.PROPERTY
+        || metadata.getParent() == null
+        || !metadata.getParent().getMetadata().isRoot()) {
+      return false;
+    }
+    Class<?> owningEntityJavaType = metadata.getParent().getType();
+    String attributeName = metadata.getName();
+    try {
+      EntityType<?> entityType = metamodel.entity(owningEntityJavaType);
+      Attribute<?, ?> attribute = entityType.getAttribute(attributeName);
+      boolean isJavaCollection =
+          java.util.Collection.class.isAssignableFrom(attribute.getJavaType());
+      boolean isPersistentBasic =
+          attribute.getPersistentAttributeType() == Attribute.PersistentAttributeType.BASIC;
+      return isJavaCollection && isPersistentBasic;
+    } catch (IllegalArgumentException e) {
+      System.err.println(
+          "QueryDSL-JPA (DEBUG): Metamodel lookup failed for " + path + ": " + e.getMessage());
+      return false;
+    }
+  }
+
   private void visitAnyInPath(
       Class<?> type, Operator operator, List<? extends Expression<?>> args) {
+    Expression<?> collectionExpression = args.get(1);
+
+    if (this.entityManager != null && collectionExpression instanceof Path<?>) {
+      Path<?> collectionPath = (Path<?>) collectionExpression;
+      jakarta.persistence.metamodel.Metamodel metamodel = this.entityManager.getMetamodel();
+      if (isCollectionPathWithConverterToBasicType(collectionPath, metamodel)) {
+        String effectiveOperatorForMessage =
+            (operator == Ops.IN)
+                ? "MEMBER OF (translated from IN)"
+                : "NOT MEMBER OF (translated from NOT IN)";
+        throw new com.querydsl.core.QueryException(
+            "QueryDSL Error: Path '"
+                + collectionPath
+                + "' is a Java collection mapped via a JPA @Converter to a basic database type. "
+                + "The QueryDSL operation '"
+                + operator.toString()
+                + "' on this path, which would typically translate to JPQL '"
+                + effectiveOperatorForMessage
+                + "', "
+                + "is not supported by JPA/Hibernate for such converted attributes as they are not treated as queryable 'plural paths'. "
+                + "Consider alternative query strategies (e.g., native queries with database-specific functions) "
+                + "or re-evaluate your entity mapping strategy.");
+      }
+    }
     super.visitOperation(
-        type, operator == Ops.IN ? JPQLOps.MEMBER_OF : JPQLOps.NOT_MEMBER_OF, args);
+        type,
+        (operator == Ops.IN
+            ? com.querydsl.jpa.JPQLOps.MEMBER_OF
+            : com.querydsl.jpa.JPQLOps.NOT_MEMBER_OF),
+        args);
   }
 
   @SuppressWarnings("unchecked")

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryConverterCollectionContainsTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryConverterCollectionContainsTest.java
@@ -1,0 +1,94 @@
+package com.querydsl.jpa;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.querydsl.jpa.domain.Alchemist;
+import com.querydsl.jpa.domain.PotionEffect;
+import com.querydsl.jpa.domain.QAlchemist;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.testutil.JPATestRunner;
+import jakarta.persistence.EntityManager;
+import java.util.EnumSet;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JPATestRunner.class)
+public class JPAQueryConverterCollectionContainsTest implements JPATest {
+
+  private EntityManager em;
+  private JPAQueryFactory queryFactory;
+
+  @Override
+  public void setEntityManager(EntityManager em) {
+    this.em = em;
+    if (this.em != null) {
+      this.queryFactory = new JPAQueryFactory(this.em);
+    }
+  }
+
+  private static final QAlchemist qAlchemist = QAlchemist.alchemist;
+
+  @Before
+  public void setUpData() {
+    if (em == null) {
+      throw new IllegalStateException("EntityManager has not been set by JPATestRunner.");
+    }
+    if (queryFactory == null) {
+      queryFactory = new JPAQueryFactory(em);
+    }
+
+    boolean newTransaction = false;
+    if (!em.getTransaction().isActive()) {
+      em.getTransaction().begin();
+      newTransaction = true;
+    }
+
+    queryFactory.delete(qAlchemist).where(qAlchemist.alchemistName.isNotNull()).execute();
+
+    em.persist(
+        new Alchemist("Merlin", EnumSet.of(PotionEffect.INVISIBILITY, PotionEffect.STRENGTH)));
+    em.persist(new Alchemist("Circe", EnumSet.of(PotionEffect.HEALING)));
+    em.persist(new Alchemist("Paracelsus", EnumSet.of(PotionEffect.STRENGTH, PotionEffect.SPEED)));
+    em.persist(new Alchemist("Zosimos", EnumSet.of(PotionEffect.INVISIBILITY)));
+
+    em.flush();
+    if (newTransaction) {
+      em.getTransaction().commit();
+    }
+    em.clear();
+
+    if (!em.getTransaction().isActive()) {
+      em.getTransaction().begin();
+    }
+  }
+
+  @After
+  public void tearDown() {
+    if (em != null && em.getTransaction().isActive()) {
+      em.getTransaction().rollback();
+    }
+  }
+
+  @Test
+  public void knownEffectsContains_ShouldThrowQueryDSLException_WhenConverterIsUsed() {
+    if (queryFactory == null) {
+      throw new IllegalStateException("JPAQueryFactory not initialized.");
+    }
+    PotionEffect searchEffect = PotionEffect.INVISIBILITY;
+
+    assertThatThrownBy(
+            () -> {
+              queryFactory
+                  .selectFrom(qAlchemist)
+                  .where(qAlchemist.knownEffects.contains(searchEffect))
+                  .fetch();
+            })
+        .isInstanceOf(com.querydsl.core.QueryException.class)
+        .hasMessageContaining(
+            "QueryDSL Error: Path 'alchemist.knownEffects' is a Java collection mapped via a JPA @Converter to a basic database type.")
+        .hasMessageContaining("The QueryDSL operation 'IN' on this path")
+        .hasMessageContaining("is not supported by JPA/Hibernate for such converted attributes");
+  }
+}

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryConverterCollectionContainsTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAQueryConverterCollectionContainsTest.java
@@ -1,5 +1,6 @@
 package com.querydsl.jpa;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.querydsl.jpa.domain.Alchemist;
@@ -8,7 +9,9 @@ import com.querydsl.jpa.domain.QAlchemist;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.querydsl.jpa.testutil.JPATestRunner;
 import jakarta.persistence.EntityManager;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,29 +42,28 @@ public class JPAQueryConverterCollectionContainsTest implements JPATest {
       queryFactory = new JPAQueryFactory(em);
     }
 
-    boolean newTransaction = false;
     if (!em.getTransaction().isActive()) {
       em.getTransaction().begin();
-      newTransaction = true;
     }
 
     queryFactory.delete(qAlchemist).where(qAlchemist.alchemistName.isNotNull()).execute();
 
     em.persist(
-        new Alchemist("Merlin", EnumSet.of(PotionEffect.INVISIBILITY, PotionEffect.STRENGTH)));
-    em.persist(new Alchemist("Circe", EnumSet.of(PotionEffect.HEALING)));
-    em.persist(new Alchemist("Paracelsus", EnumSet.of(PotionEffect.STRENGTH, PotionEffect.SPEED)));
-    em.persist(new Alchemist("Zosimos", EnumSet.of(PotionEffect.INVISIBILITY)));
+        new Alchemist(
+            "Merlin",
+            EnumSet.of(PotionEffect.INVISIBILITY, PotionEffect.STRENGTH),
+            Collections.emptyList()));
+    em.persist(new Alchemist("Circe", EnumSet.of(PotionEffect.HEALING), Collections.emptyList()));
+    em.persist(
+        new Alchemist(
+            "Paracelsus",
+            EnumSet.of(PotionEffect.STRENGTH, PotionEffect.SPEED),
+            Collections.emptyList()));
+    em.persist(
+        new Alchemist("Zosimos", EnumSet.of(PotionEffect.INVISIBILITY), Collections.emptyList()));
 
     em.flush();
-    if (newTransaction) {
-      em.getTransaction().commit();
-    }
     em.clear();
-
-    if (!em.getTransaction().isActive()) {
-      em.getTransaction().begin();
-    }
   }
 
   @After
@@ -90,5 +92,33 @@ public class JPAQueryConverterCollectionContainsTest implements JPATest {
             "QueryDSL Error: Path 'alchemist.knownEffects' is a Java collection mapped via a JPA @Converter to a basic database type.")
         .hasMessageContaining("The QueryDSL operation 'IN' on this path")
         .hasMessageContaining("is not supported by JPA/Hibernate for such converted attributes");
+  }
+
+  @Test
+  public void learnedSpellsContains_ShouldNOTThrowQueryDSLException_ForStandardCollection() {
+    if (queryFactory == null) {
+      throw new IllegalStateException("JPAQueryFactory not initialized.");
+    }
+    String searchSpell = "Fireball";
+
+    Alchemist gandalf =
+        new Alchemist(
+            "Gandalf", EnumSet.of(PotionEffect.STRENGTH), List.of("Fireball", "Lightning Bolt"));
+    em.persist(gandalf);
+    em.flush();
+
+    List<Alchemist> results =
+        queryFactory
+            .selectFrom(qAlchemist)
+            .where(
+                qAlchemist
+                    .learnedSpells
+                    .contains(searchSpell)
+                    .and(qAlchemist.alchemistName.eq("Gandalf")))
+            .fetch();
+
+    assertThat(results).isNotNull();
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getAlchemistName()).isEqualTo("Gandalf");
   }
 }

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/Alchemist.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/Alchemist.java
@@ -1,0 +1,37 @@
+package com.querydsl.jpa.domain;
+
+import jakarta.persistence.*;
+import java.util.Set;
+
+@Entity(name = "AlchemistEntity")
+@Table(name = "alchemist_effects_test")
+public class Alchemist {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  private String alchemistName;
+
+  @Convert(converter = PotionEffectSetConverter.class)
+  @Column(columnDefinition = "TEXT")
+  private Set<PotionEffect> knownEffects;
+
+  public Alchemist() {}
+
+  public Alchemist(String alchemistName, Set<PotionEffect> knownEffects) {
+    this.alchemistName = alchemistName;
+    this.knownEffects = knownEffects;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public String getAlchemistName() {
+    return alchemistName;
+  }
+
+  public Set<PotionEffect> getKnownEffects() {
+    return knownEffects;
+  }
+}

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/Alchemist.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/Alchemist.java
@@ -1,6 +1,8 @@
 package com.querydsl.jpa.domain;
 
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 @Entity(name = "AlchemistEntity")
@@ -16,11 +18,18 @@ public class Alchemist {
   @Column(columnDefinition = "TEXT")
   private Set<PotionEffect> knownEffects;
 
+  @ElementCollection
+  @CollectionTable(name = "alchemist_spells", joinColumns = @JoinColumn(name = "alchemist_id"))
+  @Column(name = "spell_name")
+  private List<String> learnedSpells = new ArrayList<>();
+
   public Alchemist() {}
 
-  public Alchemist(String alchemistName, Set<PotionEffect> knownEffects) {
+  public Alchemist(
+      String alchemistName, Set<PotionEffect> knownEffects, List<String> learnedSpells) {
     this.alchemistName = alchemistName;
     this.knownEffects = knownEffects;
+    this.learnedSpells = learnedSpells;
   }
 
   public Integer getId() {
@@ -29,6 +38,10 @@ public class Alchemist {
 
   public String getAlchemistName() {
     return alchemistName;
+  }
+
+  public List<String> getLearnedSpells() {
+    return learnedSpells;
   }
 
   public Set<PotionEffect> getKnownEffects() {

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/PotionEffect.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/PotionEffect.java
@@ -1,0 +1,8 @@
+package com.querydsl.jpa.domain;
+
+public enum PotionEffect {
+  HEALING,
+  STRENGTH,
+  INVISIBILITY,
+  SPEED
+}

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/PotionEffectSetConverter.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/PotionEffectSetConverter.java
@@ -1,0 +1,43 @@
+package com.querydsl.jpa.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Converter
+public class PotionEffectSetConverter
+    implements AttributeConverter<Set<PotionEffect>, String>, Serializable {
+  private static final long serialVersionUID = 4L;
+  private static final String DELIMITER = ";";
+
+  @Override
+  public String convertToDatabaseColumn(Set<PotionEffect> attribute) {
+    if (attribute == null || attribute.isEmpty()) {
+      return null;
+    }
+    return attribute.stream().map(PotionEffect::name).collect(Collectors.joining(DELIMITER));
+  }
+
+  @Override
+  public Set<PotionEffect> convertToEntityAttribute(String dbData) {
+    if (dbData == null || dbData.trim().isEmpty()) {
+      return Collections.emptySet();
+    }
+    String[] effectNames = dbData.split(DELIMITER);
+    Set<PotionEffect> effects = EnumSet.noneOf(PotionEffect.class);
+    for (String effectName : effectNames) {
+      try {
+        if (!effectName.trim().isEmpty()) {
+          effects.add(PotionEffect.valueOf(effectName.trim()));
+        }
+      } catch (IllegalArgumentException e) {
+        System.err.println("Warning: Could not convert '" + effectName + "' to PotionEffect enum.");
+      }
+    }
+    return effects;
+  }
+}


### PR DESCRIPTION
**Related Issue(s):** [#173 querydsl/querydsl ](https://github.com/querydsl/querydsl/issues/3618) , [#377 openfeign/querydsl](https://github.com/OpenFeign/querydsl/issues/377)

### Problem Description

When using QueryDSL's `collection.contains(element)` method on a Java `Collection`-typed entity attribute that is mapped to a basic database type (e.g., `String`, `TEXT`) via a JPA `@Converter`, QueryDSL currently generates a standard JPQL `MEMBER OF` clause (often via an internal `Ops.IN` to `JPQLOps.MEMBER_OF` translation).

Historically, some older Hibernate versions might have been less strict in validating this JPQL against such converted attributes, leading some users (like H-Lo in issue #3618, #377) to believe this pattern "worked." However, as pointed out by contributors like OrangeDog, and in line with JPA principles, an attribute converted to a basic type is not treated as a queryable "plural path" by the persistence provider for standard collection operators like `MEMBER OF`.

Consequently, modern JPA providers, especially Hibernate 6 and later with its stricter validation, now consistently reject this JPQL, resulting in a runtime `org.hibernate.query.SemanticException: Operand of 'member of' operator must be a plural path`. This exception, often wrapped, originates глубоко from the ORM layer, making it less obvious to users why their QueryDSL code, which appears type-safe, is failing.

### Justification for This Change in QueryDSL

While some users (like H-Lo) might have previously found workarounds or experienced a more lenient behavior from older Hibernate versions, the current stricter validation by Hibernate is aligned with JPA's interpretation of how `@Converter` to a basic type alters an attribute's nature for querying standard collection operations. The core issue is that **QueryDSL currently generates JPQL that is predictably incompatible with how JPA providers handle such converted collections for `MEMBER OF` operations.**

This PR proposes that QueryDSL should proactively address this known incompatibility for the following reasons:

1.  **Enhanced User Experience & Clearer Diagnostics (Fail-Fast):**
    * Instead of allowing users to encounter a potentially cryptic, ORM-specific `SemanticException` at runtime, QueryDSL can provide an immediate, clear, and QueryDSL-specific `QueryException`.
    * This exception will precisely explain *why* the operation is unsupported for that specific attribute mapping (`@Converter` on a collection to a basic type) and guide the user towards understanding the limitation and considering alternatives (like native queries for DB-specific functions or re-evaluating their mapping if collection querying is crucial).

2.  **Improved Abstraction and Predictability:**
    * QueryDSL serves as an abstraction layer. By detecting this specific pitfall, QueryDSL upholds its role by shielding users from underlying ORM intricacies that lead to predictable failures.
    * It makes QueryDSL's behavior more predictable: if an operation is known to be unsupported by the persistence layer for a given mapping, QueryDSL should ideally signal this at its level.

3.  **Alignment with Stricter ORM Validations:**
    * As ORMs like Hibernate evolve and enforce stricter adherence to specifications or improve their validation, QueryDSL should also adapt to prevent the generation of queries that will no longer be accepted. This change makes QueryDSL a better citizen in the modern JPA ecosystem.

4.  **Guidance Over Silent Failure or Unexpected Behavior:**
    * Even if older Hibernate versions didn't throw an error, it's questionable, as OrangeDog pointed out, whether the `MEMBER OF` operation on a TEXT column (without database-specific functions) ever produced the *semantically correct SQL* for a true collection membership check. It might have "not failed" but not worked as truly intended either.
    * Providing a clear error is better than QueryDSL generating a query that either fails cryptically or, in hypothetical lenient scenarios, produces SQL that doesn't match the user's intent for a collection `contains` check.

This change is not about restoring a "broken" functionality that was once correctly supported, but rather about QueryDSL taking responsibility for generating valid and semantically appropriate queries for the given context, or clearly indicating when it cannot. This PR opts for the latter by providing explicit, early feedback.

### Solution Implemented

This PR modifies the `JPQLSerializer` (specifically the `visitAnyInPath` method, which is involved when `collection.contains()` is translated from an `Ops.IN` operation on a collection path) in the `querydsl-jpa` module.

The changes are as follows:

1.  **Detection of Problematic Mapping:**
    * A new helper method, `isCollectionPathWithConverterToBasicType(Path<?> path, jakarta.persistence.metamodel.Metamodel metamodel)`, uses the JPA `Metamodel` to determine if a given QueryDSL `Path<?>` corresponds to an entity attribute that is a Java `Collection` but whose `PersistentAttributeType` is `BASIC` (indicating a JPA `@Converter` to a basic database type).

2.  **Early Exception (Fail-Fast):**
    * Within `visitAnyInPath`, before calling `super.visitOperation` to generate the `MEMBER OF` clause, this check is performed.
    * If the problematic mapping is detected, QueryDSL now throws a `com.querydsl.core.QueryException` with an informative message.

3.  **Normal Behavior for Valid Cases:**
    * If the check determines the mapping is not problematic, the existing logic proceeds, ensuring normally mapped collections are unaffected.

### Benefits of the Change

* **Improved User Experience:** Clear, QueryDSL-specific error message indicating the incompatibility.
* **Fail-Fast:** Problems identified earlier during JPQL serialization.
* **Increased Robustness:** QueryDSL handles this specific JPA mapping pattern more gracefully.

### How to Test

* A new test case, `JPAQueryConverterCollectionContainsTest.java`, has been added.
* It defines an entity with a `Set<UserRoleInTest>` attribute mapped using a custom `@Converter` (to a comma-delimited String).
* The test method `rolesContains_ShouldThrowQueryDSLException_WhenConverterIsUsedOnCollection` asserts that a `.contains()` query on this path now throws the new `com.querydsl.core.QueryException` with the expected message.

### Possible Future Enhancements (Out of Scope for this PR)

While this PR focuses on better diagnostics, future work could explore support for querying such converted collections via database-specific functions, if a generic and maintainable approach within QueryDSL is feasible. This PR provides the immediate benefit of clear error reporting for currently unsupported standard operations.

---