### PR TITLE
Exclude properties in QueryProjection outside constructor

### DIFF
--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Bear.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Bear.kt
@@ -1,0 +1,20 @@
+package com.querydsl.example.ksp
+
+import com.querydsl.core.annotations.QueryProjection
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+
+@Entity
+class Bear(
+	@Id
+	val id: Int,
+	val name: String,
+	val location: String
+)
+
+class BearSimplifiedProjection @QueryProjection constructor(
+	val id: Int,
+	val name: String,
+) {
+	var age: Int = 0
+}

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModel.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModel.kt
@@ -1,6 +1,8 @@
 package com.querydsl.ksp.codegen
 
 import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSFunction
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.squareup.kotlinpoet.ClassName
 
 class QueryModel(
@@ -8,6 +10,7 @@ class QueryModel(
     val typeParameterCount: Int,
     val className: ClassName,
     val type: QueryModelType,
+    val constructor: KSFunctionDeclaration?,
     val originatingFile: KSFile?
 ) {
     var superclass: QueryModel? = null

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/TypeExtractor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/TypeExtractor.kt
@@ -10,7 +10,8 @@ import jakarta.persistence.Convert
 
 class TypeExtractor(
     private val settings: KspSettings,
-    private val property: KSPropertyDeclaration
+    private val fullPathName: String,
+    private val annotations: Sequence<KSAnnotation>
 ) {
     fun extract(type: KSType): QPropertyType {
         val declaration = type.declaration
@@ -115,7 +116,7 @@ class TypeExtractor(
             ClassName("org.hibernate.annotations", "JdbcTypeCode"),
             Convert::class.asClassName()
         )
-        if (property.annotations.any { userTypeAnnotations.contains(it.annotationType.resolve().toClassName()) }) {
+        if (annotations.any { userTypeAnnotations.contains(it.annotationType.resolve().toClassName()) }) {
             return QPropertyType.Unknown(type.toClassNameSimple(), type.toTypeName())
         } else {
             return null
@@ -129,7 +130,7 @@ class TypeExtractor(
     }
 
     private fun throwError(message: String): Nothing {
-        error("Error processing ${property.qualifiedName!!.asString()}: $message")
+        error("Error processing $fullPathName: $message")
     }
 }
 

--- a/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/RenderTest.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/RenderTest.kt
@@ -20,6 +20,7 @@ class RenderTest {
             typeParameterCount = 0,
             className = ClassName("", "QUser"),
             type = QueryModelType.ENTITY,
+            null,
             mockk()
         )
         val properties = listOf(
@@ -55,6 +56,7 @@ class RenderTest {
             typeParameterCount = 0,
             className = ClassName("", "QCat"),
             type = QueryModelType.ENTITY,
+            null,
             mockk()
         )
         val superClass = QueryModel(
@@ -62,6 +64,7 @@ class RenderTest {
             typeParameterCount = 0,
             className = ClassName("", "QAnimal"),
             type = QueryModelType.SUPERCLASS,
+            null,
             mockk()
         )
         model.superclass = superClass
@@ -79,6 +82,7 @@ class RenderTest {
             typeParameterCount = 0,
             className = ClassName("", "QCat"),
             type = QueryModelType.ENTITY,
+            null,
             mockk()
         )
         val superClass = QueryModel(
@@ -86,6 +90,7 @@ class RenderTest {
             typeParameterCount = 0,
             className = ClassName("", "QAnimal"),
             type = QueryModelType.SUPERCLASS,
+            null,
             null
         )
         model.superclass = superClass
@@ -103,6 +108,7 @@ class RenderTest {
             typeParameterCount = 1,
             className = ClassName("", "QArticle"),
             type = QueryModelType.ENTITY,
+            null,
             mockk()
         )
         val typeSpec = QueryModelRenderer.render(model)
@@ -133,6 +139,7 @@ class RenderTest {
             typeParameterCount = 0,
             className = ClassName("", "QAnimal"),
             type = QueryModelType.ENTITY,
+            null,
             mockk()
         )
         animalModel.properties.add(
@@ -143,6 +150,7 @@ class RenderTest {
             typeParameterCount = 0,
             className = ClassName("", "QCat"),
             type = QueryModelType.ENTITY,
+            null,
             mockk()
         )
         catModel.superclass = animalModel
@@ -159,6 +167,7 @@ class RenderTest {
             typeParameterCount = 0,
             className = ClassName("", "QAnimal"),
             type = QueryModelType.ENTITY,
+            null,
             mockk()
         )
         model.properties.add(
@@ -184,6 +193,7 @@ class RenderTest {
             typeParameterCount = 0,
             className = ClassName("", "QCatDTO"),
             type = QueryModelType.QUERY_PROJECTION,
+            null,
             mockk()
         )
         val properties = listOf(


### PR DESCRIPTION
This pull request solves the issue that was reported in my original repository earlier this week.
https://github.com/IceBlizz6/querydsl-ksp/issues/9

Currently this code
```kotlin
data class PersonClassConstructorDTO @QueryProjection constructor(
    val id: Int,
    val name: String,
) {
    var age: Int = 0
}
```

Becomes
```kotlin
public class QPersonClassConstructorDTO(
    id: Expression<Int>,
    name: Expression<String>,
    age: Expression<Int>,
) : ConstructorExpression<PersonClassConstructorDTO>(PersonClassConstructorDTO::class.java, arrayOf(kotlin.Int::class.java, kotlin.String::class.java, kotlin.Int::class.java), id, name, age)
```

Which is incorrect as it should only include properties from the constructor.

For reference kapt will produce this:
```java
@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
public class QPersonClassConstructorDTO extends ConstructorExpression<PersonClassConstructorDTO> {

    private static final long serialVersionUID = 1630917992L;

    public QPersonClassConstructorDTO(com.querydsl.core.types.Expression<Integer> id, com.querydsl.core.types.Expression<String> name) {
        super(PersonClassConstructorDTO.class, new Class<?>[]{int.class, String.class}, id, name);
    }
}
```