### PR TITLE
Add fallback for unknown types in KSP

### DIFF
--- a/querydsl-examples/querydsl-example-ksp-codegen/build.gradle.kts
+++ b/querydsl-examples/querydsl-example-ksp-codegen/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
         implementation("io.github.openfeign.querydsl:querydsl-core:${querydslVersion}")
         implementation("org.hibernate.orm:hibernate-core:${hibernateVersion}")
         ksp("io.github.openfeign.querydsl:querydsl-ksp-codegen:${querydslVersion}")
+        implementation("org.locationtech.jts:jts-core:1.19.0")
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.19.0")
         testImplementation("io.github.openfeign.querydsl:querydsl-jpa:${querydslVersion}")
         testImplementation("org.assertj:assertj-core:${assertjVersion}")

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Geolocation.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Geolocation.kt
@@ -1,0 +1,14 @@
+package com.querydsl.example.ksp
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import org.locationtech.jts.geom.Point
+
+@Entity
+class Geolocation(
+	@Id
+	val id: Int,
+	@Column(columnDefinition = "geography(Point, 4326)")
+	var location: Point? = null,
+)

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/test/kotlin/Tests.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/test/kotlin/Tests.kt
@@ -7,6 +7,7 @@ import com.querydsl.example.ksp.QBear
 import com.querydsl.example.ksp.QBearSimplifiedProjection
 import com.querydsl.example.ksp.QCat
 import com.querydsl.example.ksp.QDog
+import com.querydsl.example.ksp.QGeolocation
 import com.querydsl.example.ksp.QPerson
 import com.querydsl.example.ksp.QPersonClassDTO
 import com.querydsl.example.ksp.QPersonClassConstructorDTO
@@ -246,6 +247,16 @@ class Tests {
 
             em.close()
         }
+    }
+
+    @Test
+    fun `is detecting comparable interface on unknown type`() {
+        val locationTypeName = QGeolocation::class
+            .members
+            .first { it.name == "location" }
+            .returnType
+            .toString()
+        assertThat(locationTypeName).isEqualTo("com.querydsl.core.types.dsl.ComparablePath<org.locationtech.jts.geom.Point>")
     }
 
     private fun initialize(): EntityManagerFactory {


### PR DESCRIPTION
This PR is attempting to solve #1255 

Currently KSP module will throw exception when it encounters an arbitrary type without hibernate annotations, because it believes this is invalid and will alert the user to make the correct configuration.

But there seems to exist cases where arbitrary types are allowed (possibly through plugins?).

This PR adds a fallback where it uses ComparablePath if the type implements Compararable interface and otherwise it uses SimplePath.
