### PR TITLE
Add support for subquery modifiers (LIMIT/OFFSET) in Hibernate

### DIFF
--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/HQLTemplates.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/HQLTemplates.java
@@ -116,4 +116,9 @@ public class HQLTemplates extends JPQLTemplates {
   public boolean isCaseWithLiterals() {
     return true;
   }
+
+  @Override
+  public boolean isSubQueryModifiersSupported() {
+    return true;
+  }
 }

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
@@ -16,6 +16,7 @@ package com.querydsl.jpa;
 import com.querydsl.core.JoinExpression;
 import com.querydsl.core.JoinType;
 import com.querydsl.core.QueryMetadata;
+import com.querydsl.core.QueryModifiers;
 import com.querydsl.core.support.SerializerBase;
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.Expressions;
@@ -64,6 +65,10 @@ public class JPQLSerializer extends SerializerBase<JPQLSerializer> {
   private static final String HAVING = "\nhaving ";
 
   private static final String ORDER_BY = "\norder by ";
+
+  private static final String LIMIT = "\nlimit ";
+
+  private static final String OFFSET = "\noffset ";
 
   private static final String SELECT = "select ";
 
@@ -412,8 +417,23 @@ public class JPQLSerializer extends SerializerBase<JPQLSerializer> {
 
   @Override
   public Void visit(SubQueryExpression<?> query, Void context) {
+    QueryMetadata metadata = query.getMetadata();
+    QueryModifiers modifiers = metadata.getModifiers();
+
     append("(");
-    serialize(query.getMetadata(), false, null);
+    serialize(metadata, false, null);
+
+    if (modifiers != null
+        && modifiers.isRestricting()
+        && templates.isSubQueryModifiersSupported()) {
+      if (modifiers.getLimit() != null) {
+        append(LIMIT).handle(modifiers.getLimit());
+      }
+      if (modifiers.getOffset() != null) {
+        append(OFFSET).handle(modifiers.getOffset());
+      }
+    }
+
     append(")");
     return null;
   }

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLTemplates.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLTemplates.java
@@ -236,4 +236,8 @@ public class JPQLTemplates extends Templates {
     }
     return builder.toString();
   }
+
+  public boolean isSubQueryModifiersSupported() {
+    return false;
+  }
 }

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPQLTemplatesTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPQLTemplatesTest.java
@@ -95,4 +95,16 @@ public class JPQLTemplatesTest {
       TemplatesTestUtils.testPrecedence(templates);
     }
   }
+
+  @Test
+  public void subQueryModifiers_support() {
+    assertThat(JPQLTemplates.DEFAULT.isSubQueryModifiersSupported()).isFalse();
+    assertThat(new EclipseLinkTemplates().isSubQueryModifiersSupported()).isFalse();
+    assertThat(new OpenJPATemplates().isSubQueryModifiersSupported()).isFalse();
+    assertThat(new DataNucleusTemplates().isSubQueryModifiersSupported()).isFalse();
+    assertThat(new BatooTemplates().isSubQueryModifiersSupported()).isFalse();
+
+    assertThat(HQLTemplates.DEFAULT.isSubQueryModifiersSupported()).isTrue();
+    assertThat(new HQLTemplates().isSubQueryModifiersSupported()).isTrue();
+  }
 }


### PR DESCRIPTION
## Description

This PR addresses a long-standing limitation in QueryDSL where LIMIT and OFFSET modifiers were ignored when used within subqueries. This change enables full subquery modifier support specifically for Hibernate users while maintaining backward compatibility and JPQL standard compliance for other JPA providers.

**Related Issue**: This resolves the subquery modifier limitation reported in [querydsl/querydsl#3224](https://github.com/querydsl/querydsl/issues/3224)

## Problem Statement

Previously, when users applied `.limit()` or `.offset()` to subqueries, modifiers were silently ignored during query serialization. This was particularly frustrating for Hibernate users since Hibernate 6.0+ natively supports LIMIT/OFFSET in subqueries, but QueryDSL wasn't utilizing this capability.

**Example of previous behavior:**
```java
// This would ignore the .limit(1) in the subquery
query.select(cat)
    .from(cat)
    .where(cat.id.in(
        JPAExpressions.select(mate.id)
            .from(mate)
            .where(mate.weight.gt(5))
            .limit(1)  // ← This was ignored!
    ))
    .fetch();
```

Solution

This implementation introduces a template-based approach that allows JPA provider-specific handling of subquery modifiers:

🔧 Core Changes

1. Template Support Detection
  - Added isSubQueryModifiersSupported() method to JPQLTemplates
  - Returns false by default (standard JPQL compliance)
  - Overridden in HQLTemplates to return true (Hibernate-specific support)

2. Conditional Serialization
  - Enhanced JPQLSerializer.visit(SubQueryExpression) to conditionally serialize modifiers
  - Only applies LIMIT/OFFSET when the template supports it
  - Preserves existing behavior for all other JPA providers

3. Serialization Constants
  - Added LIMIT and OFFSET constants for consistent formatting
  - Follows existing QueryDSL serialization patterns

📋 Supported Scenarios

- ✅ Subqueries in WHERE clauses with LIMIT/OFFSET
- ✅ Scalar subqueries in SELECT clauses with modifiers
- ✅ Nested subqueries with independent modifiers
- ✅ Combined LIMIT and OFFSET usage

Compatibility

✅ Backward Compatibility

- Zero breaking changes to existing APIs
- All existing queries continue to work exactly as before
- No impact on users not using subquery modifiers

🎯 Provider Support

- Hibernate: ✅ Full subquery modifier support (new feature)
- EclipseLink: ⭕ No change (maintains current behavior)
- OpenJPA: ⭕ No change (maintains current behavior)
- DataNucleus: ⭕ No change (maintains current behavior)
- BatooJPA: ⭕ No change (maintains current behavior)

Technical Implementation Details

The implementation uses a template-based approach to maintain provider neutrality:

1. JPQLTemplates.isSubQueryModifiersSupported(): Base method returns false (JPQL standard)
2. HQLTemplates.isSubQueryModifiersSupported(): Override returns true (Hibernate extension)
3. JPQLSerializer: Conditionally serializes modifiers based on template support

This design ensures that:
- Standard JPQL compliance is maintained for most providers
- Hibernate-specific features are enabled only when appropriate
- Future providers can easily add support by overriding the template method