### PR TITLE
Support spatial types for KSP

### DIFF
--- a/querydsl-examples/querydsl-example-ksp-codegen/build.gradle.kts
+++ b/querydsl-examples/querydsl-example-ksp-codegen/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 dependencies {
         implementation("jakarta.persistence:jakarta.persistence-api:${jpaVersion}")
         implementation("io.github.openfeign.querydsl:querydsl-core:${querydslVersion}")
+        implementation("io.github.openfeign.querydsl:querydsl-spatial:${querydslVersion}")
         implementation("org.hibernate.orm:hibernate-core:${hibernateVersion}")
         ksp("io.github.openfeign.querydsl:querydsl-ksp-codegen:${querydslVersion}")
         implementation("org.locationtech.jts:jts-core:1.19.0")

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/MyShape.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/MyShape.kt
@@ -1,0 +1,15 @@
+package com.querydsl.example.ksp
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import org.locationtech.jts.geom.Geometry
+
+@Entity
+class MyShape(
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	val id: Long = 0,
+	val departureGeo: Geometry? = null
+)

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/test/kotlin/Tests.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/test/kotlin/Tests.kt
@@ -8,6 +8,7 @@ import com.querydsl.example.ksp.QBearSimplifiedProjection
 import com.querydsl.example.ksp.QCat
 import com.querydsl.example.ksp.QDog
 import com.querydsl.example.ksp.QGeolocation
+import com.querydsl.example.ksp.QMyShape
 import com.querydsl.example.ksp.QPerson
 import com.querydsl.example.ksp.QPersonClassDTO
 import com.querydsl.example.ksp.QPersonClassConstructorDTO
@@ -19,7 +20,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.hibernate.cfg.Configuration
 import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.jvmErasure
 import kotlin.test.Test
 
 class Tests {
@@ -249,15 +252,12 @@ class Tests {
         }
     }
 
-    @Test
-    fun `is detecting comparable interface on unknown type`() {
-        val locationTypeName = QGeolocation::class
-            .members
-            .first { it.name == "location" }
-            .returnType
-            .toString()
-        assertThat(locationTypeName).isEqualTo("com.querydsl.core.types.dsl.ComparablePath<org.locationtech.jts.geom.Point>")
-    }
+	@Test
+	fun ensureCorrectGeoType() {
+		val departureProperty = QMyShape::class.memberProperties.single { it.name == "departureGeo" }
+		assertThat(departureProperty.returnType.jvmErasure.qualifiedName!!).isEqualTo("com.querydsl.spatial.locationtech.jts.JTSGeometryPath")
+		assertThat(departureProperty.returnType.arguments.single().type!!.jvmErasure.qualifiedName!!).isEqualTo("org.locationtech.jts.geom.Geometry")
+	}
 
     private fun initialize(): EntityManagerFactory {
         val configuration = Configuration()

--- a/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/RenderTest.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/RenderTest.kt
@@ -253,6 +253,32 @@ class RenderTest {
         code.assertContains("class QLevel1_Level2_Level3")
         code.assertContains("EntityPathBase<Level1.Level2.Level3>")
     }
+
+	@Test
+	fun geometryTypeRendering() {
+		val model = QueryModel(
+			originalClassName = ClassName("", "MyShape"),
+			typeParameterCount = 0,
+			className = ClassName("", "QMyShape"),
+			type = QueryModelType.ENTITY,
+			null,
+			mockk()
+		)
+		val properties = listOf(
+			QProperty(
+				"geometry",
+				QPropertyType.Simple(
+					SimpleType.Mapper.get(ClassName("org.locationtech.jts.geom", "Geometry"))!!
+				)
+			)
+		)
+		model.properties.addAll(properties)
+		val typeSpec = QueryModelRenderer.render(model)
+		val code = typeSpec.toString()
+		code.assertContains("""
+			public val geometry: com.querydsl.spatial.locationtech.jts.JTSGeometryPath<org.locationtech.jts.geom.Geometry> = com.querydsl.spatial.locationtech.jts.JTSGeometryPath(forProperty("geometry"))
+		""".trimIndent())
+	}
 }
 
 private fun String.assertLines(expected: String) {


### PR DESCRIPTION
KSP will correctly process spatial types in entities.
Solves #1375
