### PR TITLE
annotate KSP generated classes with @Generated

### DIFF
--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelRenderer.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelRenderer.kt
@@ -1,5 +1,6 @@
 package com.querydsl.ksp.codegen
 
+import com.querydsl.core.annotations.Generated
 import com.querydsl.core.types.ConstructorExpression
 import com.querydsl.core.types.Path
 import com.querydsl.core.types.PathMetadata
@@ -16,6 +17,7 @@ object QueryModelRenderer {
                 .setPrimaryConstructor(model)
                 .setEntitySuperclass(model)
                 .addSuperConstructorParameter(model)
+                .addAnnotation(Generated::class)
                 .build()
 
             else -> TypeSpec.classBuilder(model.className)
@@ -28,6 +30,7 @@ object QueryModelRenderer {
                 .constructorForTypeMetadata(model)
                 .addInitializerCompanionObject(model)
                 .addInheritedProperties(model)
+                .addAnnotation(Generated::class)
                 .build()
         }
     }


### PR DESCRIPTION
I used KSP to generate my query models. I wanted to use these in my Spring Boot / Kotlin application, but I ran into this error: 
```
java.lang.IllegalStateException: Could not access method or field: class org.springframework.util.ReflectionUtils cannot access a member of class nl.ruddur.jobtrans.repository.company.QCustomer with modifiers "private final"
```

The same error is also discussed in https://github.com/querydsl/querydsl/discussions/3036 .
By annotating the generated classes with `@Generated` I can use the Kotlin allopen compiler plugin to mark these classes as `open` and thus allowing Spring's `ReflectionUtils` to access the fields in the generated class. 

I.e. in my `build.gradle.kts` I can do this:
```kotlin
plugins {
    kotlin("jvm")
    kotlin("plugin.jpa")
    kotlin("plugin.allopen")
}

allOpen {
    annotation("com.querydsl.core.annotations.Generated")
}
```