### PR TITLE
Support underlying type extraction for Kotlin value classes in KSP codegen

### DIFF
--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Email.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Email.kt
@@ -1,0 +1,6 @@
+package com.querydsl.example.ksp
+
+@JvmInline
+value class Email(
+    val value: String
+)

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Person.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Person.kt
@@ -9,6 +9,7 @@ class Person(
     @Id
     val id: Int,
     val name: String,
+    val email: Email,
 
     @OneToMany(mappedBy = "owner")
     val cats: List<Cat>? = null,

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/test/kotlin/Tests.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/test/kotlin/Tests.kt
@@ -2,12 +2,12 @@ import com.querydsl.example.ksp.Bear
 import com.querydsl.example.ksp.Cat
 import com.querydsl.example.ksp.CatType
 import com.querydsl.example.ksp.Dog
+import com.querydsl.example.ksp.Email
 import com.querydsl.example.ksp.Person
 import com.querydsl.example.ksp.QBear
 import com.querydsl.example.ksp.QBearSimplifiedProjection
 import com.querydsl.example.ksp.QCat
 import com.querydsl.example.ksp.QDog
-import com.querydsl.example.ksp.QGeolocation
 import com.querydsl.example.ksp.QMyShape
 import com.querydsl.example.ksp.QPerson
 import com.querydsl.example.ksp.QPersonClassDTO
@@ -33,7 +33,7 @@ class Tests {
         run {
             val em = emf.createEntityManager()
             em.transaction.begin()
-            em.persist(Person(424, "John Smith"))
+            em.persist(Person(424, "John Smith", Email("abc@domain.com")))
             em.transaction.commit()
             em.close()
         }
@@ -44,7 +44,7 @@ class Tests {
             val q = QPerson.person
             val person = queryFactory
                 .selectFrom(q)
-                .where(q.name.eq("John Smith"))
+                .where(q.name.eq("John Smith"), q.email.eq("abc@domain.com"))
                 .fetchOne()
             if (person == null) {
                 fail<Any>("No person was returned")
@@ -62,7 +62,7 @@ class Tests {
         run {
             val em = emf.createEntityManager()
             em.transaction.begin()
-            val catOwner = Person(425, "Percy Bysshe Catownerly")
+            val catOwner = Person(425, "Percy Bysshe Catownerly", Email("abc@domain.com"))
             em.persist(catOwner)
             em.persist(Cat(103, "Samuel Taylor Cattingridge", false, "Not so fluffy", catOwner, CatType.MAINE_COON))
             em.transaction.commit()
@@ -132,7 +132,7 @@ class Tests {
         run {
             val em = emf.createEntityManager()
             em.transaction.begin()
-            em.persist(Person(424, "John Smith"))
+            em.persist(Person(424, "John Smith", Email("abc@domain.com")))
             em.transaction.commit()
             em.close()
         }


### PR DESCRIPTION
## Summary

resolves #1403 

Fixed codegen error when processing Kotlin value class columns by extracting their underlying wrapped type.

## Changes

Modified `TypeExtractor.kt` to detect value classes.
