### PR TITLE
Fix KSP enum codegen with Convert annotation

### DIFF
--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Bear.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Bear.kt
@@ -1,6 +1,7 @@
 package com.querydsl.example.ksp
 
 import com.querydsl.core.annotations.QueryProjection
+import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 
@@ -9,7 +10,9 @@ class Bear(
 	@Id
 	val id: Int,
 	val name: String,
-	val location: String
+	val location: String,
+	@Convert(converter = BearSpeciesConverter::class)
+	val species: BearSpecies?
 )
 
 class BearSimplifiedProjection @QueryProjection constructor(

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/BearSpecies.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/BearSpecies.kt
@@ -1,0 +1,9 @@
+package com.querydsl.example.ksp
+
+enum class BearSpecies {
+    BROWN_BEAR,
+    BLACK_BEAR,
+    POLAR_BEAR,
+    PANDA,
+    SUN_BEAR,
+}

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/BearSpeciesConverter.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/BearSpeciesConverter.kt
@@ -1,0 +1,22 @@
+package com.querydsl.example.ksp
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class BearSpeciesConverter : AttributeConverter<BearSpecies, String> {
+    
+    override fun convertToDatabaseColumn(attribute: BearSpecies?): String? {
+        return attribute?.name?.lowercase()
+    }
+    
+    override fun convertToEntityAttribute(dbData: String?): BearSpecies? {
+        return dbData?.let { 
+            try {
+                BearSpecies.valueOf(it.uppercase())
+            } catch (e: IllegalArgumentException) {
+                null
+            }
+        }
+    }
+}

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/TypeExtractor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/TypeExtractor.kt
@@ -145,6 +145,10 @@ class TypeExtractor(
     }
 
     private fun userType(type: KSType): QPropertyType.Unknown? {
+        if (type.isEnum()) {
+            return null
+        }
+
         val userTypeAnnotations = listOf(
             ClassName("org.hibernate.annotations", "Type"),
             ClassName("org.hibernate.annotations", "JdbcTypeCode"),
@@ -203,4 +207,10 @@ private fun KSType.toClassNameSimple(): ClassName {
         is KSTypeParameter -> error("Cannot convert KSTypeParameter to ClassName: '$this'")
         else -> error("Could not compute ClassName for '$this'")
     }
+}
+
+private fun KSType.isEnum(): Boolean {
+    val referencedDeclaration = declaration
+
+    return referencedDeclaration is KSClassDeclaration && referencedDeclaration.classKind == ClassKind.ENUM_CLASS
 }


### PR DESCRIPTION
resovles #1410 

### Problem
Enum fields with `@Convert` annotation were generating `SimplePath` instead of `EnumPath`, preventing enum-specific operations like `coalesce()`.

### Solution
Added early enum type check in `TypeExtractor.userType()` to ensure enums are processed by `referenceType()` before checking user type annotations.

### Changes
- Modified `TypeExtractor.kt` to skip enum types in `userType()`
- Added `isEnum()` helper function
- Added test case verifying `coalesce()` works on enum with `@Convert`