### PR TITLE
issue #1421 fix for mongoDb dynamic arguments

### DIFF
--- a/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
+++ b/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
@@ -13,10 +13,7 @@
  */
 package com.querydsl.mongodb;
 
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBObject;
-import com.mongodb.DBRef;
+import com.mongodb.*;
 import com.querydsl.core.types.Constant;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;
@@ -32,10 +29,7 @@ import com.querydsl.core.types.PathType;
 import com.querydsl.core.types.SubQueryExpression;
 import com.querydsl.core.types.TemplateExpression;
 import com.querydsl.core.types.Visitor;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 import org.bson.BSONObject;
 import org.bson.conversions.Bson;
@@ -48,6 +42,9 @@ import org.bson.types.ObjectId;
  * @author sangyong choi
  */
 public abstract class MongodbSerializer implements Visitor<Object, Void> {
+
+  public static final String MONGO_EXPRESSION = "$expr";
+  public static final String MONGO_EXPR_SYMBOL = "$";
 
   public Object handle(Expression<?> expression) {
     return expression.accept(this, null);
@@ -99,6 +96,162 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
     return new BasicDBObject(key, value);
   }
 
+  protected DBObject asDBObjectOrExpressionNotIn(Operation<?> expr, int exprIndex, int constIndex) {
+    boolean rightConst = expr.getArg(constIndex) instanceof Constant<?>;
+    boolean rightCollectionConst =
+        rightConst && Collection.class.isAssignableFrom(expr.getArg(constIndex).getType());
+    if (rightCollectionConst) {
+      @SuppressWarnings("unchecked") // guarded by previous check
+      Collection<?> values =
+          ((Constant<? extends Collection<?>>) expr.getArg(constIndex)).getConstant();
+      return asDBObject(asDBKey(expr, exprIndex), asDBObject("$nin", values.toArray()));
+    } else if (rightConst) {
+      Path<?> path = (Path<?>) expr.getArg(exprIndex);
+      Constant<?> constant = (Constant<?>) expr.getArg(constIndex);
+      return asDBObject(asDBKey(expr, exprIndex), asDBObject("$ne", convert(path, constant)));
+    } else {
+      Object leftField = MONGO_EXPR_SYMBOL + asDBKey(expr, constIndex);
+      Object rightValue = expr.getArg(exprIndex).accept(this, null);
+      List<BasicDBObject> conditions = new ArrayList<>();
+
+      if (Collection.class.isAssignableFrom(rightValue.getClass())) {
+        for (Object rv : (Collection<?>) rightValue) {
+          conditions.add(
+              new BasicDBObject(
+                  "$ne", Arrays.asList(leftField, MONGO_EXPR_SYMBOL + rv.toString())));
+        }
+      } else {
+        conditions.add(new BasicDBObject("$ne", Arrays.asList(leftField, rightValue)));
+      }
+      return new BasicDBObject(MONGO_EXPRESSION, new BasicDBObject("$and", conditions));
+    }
+  }
+
+  protected DBObject asDBObjectOrExpressionIn(Operation<?> expr, int exprIndex, int constIndex) {
+    boolean rightConst = expr.getArg(constIndex) instanceof Constant<?>;
+    boolean rightCollectionConst =
+        rightConst && Collection.class.isAssignableFrom(expr.getArg(constIndex).getType());
+    if (rightCollectionConst) {
+      @SuppressWarnings("unchecked")
+      Collection<?> values =
+          ((Constant<? extends Collection<?>>) expr.getArg(constIndex)).getConstant();
+      return asDBObject(asDBKey(expr, exprIndex), new BasicDBObject("$in", values.toArray()));
+    } else if (rightConst) {
+      Path<?> path = (Path<?>) expr.getArg(exprIndex);
+      Constant<?> constant = (Constant<?>) expr.getArg(constIndex);
+      return asDBObject(asDBKey(expr, exprIndex), convert(path, constant));
+    } else {
+      Object rightField = MONGO_EXPR_SYMBOL + asDBKey(expr, constIndex);
+      Object valueField;
+      Object leftValue = expr.getArg(exprIndex).accept(this, null);
+      if (Collection.class.isAssignableFrom(leftValue.getClass())) {
+        valueField =
+            ((Collection<?>) leftValue)
+                .stream().map(v -> MONGO_EXPR_SYMBOL + v.toString()).toList();
+      } else {
+        valueField = List.of(MONGO_EXPR_SYMBOL + asDBKey(expr, exprIndex));
+      }
+      BasicDBObject inCondition = new BasicDBObject("$in", Arrays.asList(rightField, valueField));
+      return new BasicDBObject(MONGO_EXPRESSION, inCondition);
+    }
+  }
+
+  private Object asDbList(Operation<?> expr) {
+    List<Expression<?>> values = (expr.getArgs().stream().toList());
+    return values.stream()
+        .map(v -> v.accept(this, null))
+        .flatMap(
+            o -> {
+              if (o instanceof Collection<?> coll) {
+                return coll.stream();
+              } else {
+                return Arrays.stream(new Object[] {o});
+              }
+            })
+        .toList();
+  }
+
+  protected DBObject asDBObjectOrExpressionBetween(Operation<?> expr) {
+    boolean arg1Const = expr.getArg(1) instanceof Constant<?>;
+    boolean arg2Const = expr.getArg(2) instanceof Constant<?>;
+
+    if (arg1Const && arg2Const) {
+      BasicDBObject range =
+          new BasicDBObject("$gte", asDBValue(expr, 1)).append("$lte", asDBValue(expr, 2));
+      return asDBObject(asDBKey(expr, 0), range);
+    } else {
+      Object leftField = MONGO_EXPR_SYMBOL + asDBKey(expr, 0);
+      Object right1 = arg1Const ? asDBValue(expr, 1) : MONGO_EXPR_SYMBOL + asDBKey(expr, 1);
+      Object right2 = arg2Const ? asDBValue(expr, 2) : MONGO_EXPR_SYMBOL + asDBKey(expr, 2);
+      BasicDBObject gteCondition =
+          new BasicDBObject("$gte", java.util.Arrays.asList(leftField, right1));
+      BasicDBObject lteCondition =
+          new BasicDBObject("$lte", java.util.Arrays.asList(leftField, right2));
+
+      BasicDBObject inner =
+          new BasicDBObject("$and", java.util.Arrays.asList(gteCondition, lteCondition));
+      return new BasicDBObject(MONGO_EXPRESSION, inner);
+    }
+  }
+
+  protected DBObject asDBObjectOrExpresson(String op, Operation<?> expr) {
+    if (expr.getArg(1) instanceof Constant<?>) { // preferred if constant for better performance
+      return asDBObject(asDBKey(expr, 0), asDBObject(op, asDBValue(expr, 1)));
+    } else {
+      return asExpression(op, asDBKey(expr, 0), asDBKey(expr, 1));
+    }
+  }
+
+  protected BasicDBObject asExpression(String op, String left, Object right) {
+    BasicDBObject inner =
+        new BasicDBObject(
+            op, java.util.Arrays.asList(MONGO_EXPR_SYMBOL + left, MONGO_EXPR_SYMBOL + right));
+    return new BasicDBObject(MONGO_EXPRESSION, inner);
+  }
+
+  private enum STRING_MATCH_TYPE {
+    STARTS_WITH,
+    ENDS_WITH,
+    EQUALS,
+    CONTAINS,
+    MATCHES;
+
+    public Function<Object, List<?>> toRegex() {
+      return s -> {
+        switch (this) {
+          case STARTS_WITH:
+            return List.of("^", s);
+          case ENDS_WITH:
+            return List.of("", s, "\\$");
+          case EQUALS:
+            return List.of("^", s, "\\$");
+          case CONTAINS:
+            return List.of(".*", s, ".*");
+          case MATCHES:
+            return List.of(s);
+          default:
+            throw new IllegalArgumentException("Unknown match type: " + this);
+        }
+      };
+    }
+  }
+
+  private BasicDBObject createRegexMatch(
+      Operation<?> expr, boolean ignoreCase, STRING_MATCH_TYPE startsWithOrEndsWith) {
+    Object leftField = MONGO_EXPR_SYMBOL + asDBKey(expr, 0);
+    Object rightField = MONGO_EXPR_SYMBOL + asDBKey(expr, 1);
+
+    BasicDBObject regexMatch = new BasicDBObject();
+    regexMatch.put("input", leftField);
+    regexMatch.put(
+        "regex", new BasicDBObject("$concat", startsWithOrEndsWith.toRegex().apply(rightField)));
+    if (ignoreCase) {
+      regexMatch.put("options", "i");
+    }
+    BasicDBObject exprObj = new BasicDBObject("$regexMatch", regexMatch);
+    return new BasicDBObject(MONGO_EXPRESSION, exprObj);
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public Object visit(Operation<?> expr, Void context) {
@@ -113,8 +266,16 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
         }
       } else if (expr.getArg(0) instanceof Path) {
         Path<?> path = (Path<?>) expr.getArg(0);
-        Constant<?> constant = (Constant<?>) expr.getArg(1);
-        return asDBObject(asDBKey(expr, 0), convert(path, constant));
+        Object constant = expr.getArg(1);
+        if (constant instanceof Constant<?> constatntValue) {
+          return asDBObject(asDBKey(expr, 0), convert(path, constatntValue));
+        } else {
+          Object rightField = MONGO_EXPR_SYMBOL + asDBKey(expr, 1);
+          Object leftField = MONGO_EXPR_SYMBOL + asDBKey(expr, 0);
+          BasicDBObject eqCondition =
+              new BasicDBObject("$eq", Arrays.asList(leftField, rightField));
+          return new BasicDBObject(MONGO_EXPRESSION, eqCondition);
+        }
       }
     } else if (op == Ops.STRING_IS_EMPTY) {
       return asDBObject(asDBKey(expr, 0), "");
@@ -154,56 +315,104 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
 
     } else if (op == Ops.NE) {
       Path<?> path = (Path<?>) expr.getArg(0);
-      Constant<?> constant = (Constant<?>) expr.getArg(1);
-      return asDBObject(asDBKey(expr, 0), asDBObject("$ne", convert(path, constant)));
+      Object constant = expr.getArg(1);
+      if (constant instanceof Constant<?> constatntValue) {
+        return asDBObject(asDBKey(expr, 0), asDBObject("$ne", convert(path, constatntValue)));
+      } else {
+        Object rightField = MONGO_EXPR_SYMBOL + asDBKey(expr, 1);
+        Object leftField = MONGO_EXPR_SYMBOL + asDBKey(expr, 0);
+        BasicDBObject eqCondition = new BasicDBObject("$ne", Arrays.asList(leftField, rightField));
+        return new BasicDBObject(MONGO_EXPRESSION, eqCondition);
+      }
 
     } else if (op == Ops.STARTS_WITH) {
-      return asDBObject(asDBKey(expr, 0), Pattern.compile("^" + regexValue(expr, 1)));
+
+      if (expr.getArg(1) instanceof Constant<?>) {
+        return asDBObject(asDBKey(expr, 0), Pattern.compile("^" + regexValue(expr, 1)));
+      } else {
+        return createRegexMatch(expr, false, STRING_MATCH_TYPE.STARTS_WITH);
+      }
 
     } else if (op == Ops.STARTS_WITH_IC) {
-      return asDBObject(
-          asDBKey(expr, 0), Pattern.compile("^" + regexValue(expr, 1), Pattern.CASE_INSENSITIVE));
+      if (expr.getArg(1) instanceof Constant<?>) {
+        return asDBObject(
+            asDBKey(expr, 0), Pattern.compile("^" + regexValue(expr, 1), Pattern.CASE_INSENSITIVE));
+      } else {
+        return createRegexMatch(expr, true, STRING_MATCH_TYPE.STARTS_WITH);
+      }
 
     } else if (op == Ops.ENDS_WITH) {
-      return asDBObject(asDBKey(expr, 0), Pattern.compile(regexValue(expr, 1) + "$"));
+      if (expr.getArg(1) instanceof Constant<?>) {
+        return asDBObject(asDBKey(expr, 0), Pattern.compile(regexValue(expr, 1) + "$"));
+      } else {
+        return createRegexMatch(expr, false, STRING_MATCH_TYPE.ENDS_WITH);
+      }
 
     } else if (op == Ops.ENDS_WITH_IC) {
-      return asDBObject(
-          asDBKey(expr, 0), Pattern.compile(regexValue(expr, 1) + "$", Pattern.CASE_INSENSITIVE));
-
+      if (expr.getArg(1) instanceof Constant<?>) {
+        return asDBObject(
+            asDBKey(expr, 0), Pattern.compile(regexValue(expr, 1) + "$", Pattern.CASE_INSENSITIVE));
+      } else {
+        return createRegexMatch(expr, true, STRING_MATCH_TYPE.ENDS_WITH);
+      }
     } else if (op == Ops.EQ_IGNORE_CASE) {
-      return asDBObject(
-          asDBKey(expr, 0),
-          Pattern.compile("^" + regexValue(expr, 1) + "$", Pattern.CASE_INSENSITIVE));
+      if (expr.getArg(1) instanceof Constant<?>) {
+        asDBObject(
+            asDBKey(expr, 0),
+            Pattern.compile("^" + regexValue(expr, 1) + "$", Pattern.CASE_INSENSITIVE));
+      } else {
+        return createRegexMatch(expr, true, STRING_MATCH_TYPE.EQUALS);
+      }
 
     } else if (op == Ops.STRING_CONTAINS) {
-      return asDBObject(asDBKey(expr, 0), Pattern.compile(".*" + regexValue(expr, 1) + ".*"));
+      if (expr.getArg(1) instanceof Constant<?>) {
+        return asDBObject(asDBKey(expr, 0), Pattern.compile(".*" + regexValue(expr, 1) + ".*"));
+      } else {
+        return createRegexMatch(expr, false, STRING_MATCH_TYPE.CONTAINS);
+      }
 
     } else if (op == Ops.STRING_CONTAINS_IC) {
-      return asDBObject(
-          asDBKey(expr, 0),
-          Pattern.compile(".*" + regexValue(expr, 1) + ".*", Pattern.CASE_INSENSITIVE));
-
+      if (expr.getArg(1) instanceof Constant<?>) {
+        return asDBObject(
+            asDBKey(expr, 0),
+            Pattern.compile(".*" + regexValue(expr, 1) + ".*", Pattern.CASE_INSENSITIVE));
+      } else {
+        return createRegexMatch(expr, true, STRING_MATCH_TYPE.CONTAINS);
+      }
     } else if (op == Ops.MATCHES) {
-      return asDBObject(asDBKey(expr, 0), Pattern.compile(asDBValue(expr, 1).toString()));
+      if (expr.getArg(1) instanceof Constant<?>) {
+        return asDBObject(asDBKey(expr, 0), Pattern.compile(asDBValue(expr, 1).toString()));
+      } else {
+        return createRegexMatch(expr, false, STRING_MATCH_TYPE.MATCHES);
+      }
 
     } else if (op == Ops.MATCHES_IC) {
-      return asDBObject(
-          asDBKey(expr, 0),
-          Pattern.compile(asDBValue(expr, 1).toString(), Pattern.CASE_INSENSITIVE));
+      if (expr.getArg(1) instanceof Constant<?>) {
+        return asDBObject(
+            asDBKey(expr, 0),
+            Pattern.compile(asDBValue(expr, 1).toString(), Pattern.CASE_INSENSITIVE));
+      } else {
+        return createRegexMatch(expr, true, STRING_MATCH_TYPE.MATCHES);
+      }
 
     } else if (op == Ops.LIKE) {
-      var regex = ExpressionUtils.likeToRegex((Expression) expr.getArg(1)).toString();
-      return asDBObject(asDBKey(expr, 0), Pattern.compile(regex));
+      if (expr.getArg(1) instanceof Constant<?>) {
+        var regex = ExpressionUtils.likeToRegex((Expression) expr.getArg(1)).toString();
+        return asDBObject(asDBKey(expr, 0), Pattern.compile(regex));
+      } else {
+        return createRegexMatch(expr, false, STRING_MATCH_TYPE.MATCHES);
+      }
 
     } else if (op == Ops.LIKE_IC) {
-      var regex = ExpressionUtils.likeToRegex((Expression) expr.getArg(1)).toString();
-      return asDBObject(asDBKey(expr, 0), Pattern.compile(regex, Pattern.CASE_INSENSITIVE));
+      if (expr.getArg(1) instanceof Constant<?>) {
+        var regex = ExpressionUtils.likeToRegex((Expression) expr.getArg(1)).toString();
+        return asDBObject(asDBKey(expr, 0), Pattern.compile(regex, Pattern.CASE_INSENSITIVE));
+      } else {
+        return createRegexMatch(expr, true, STRING_MATCH_TYPE.MATCHES);
+      }
 
     } else if (op == Ops.BETWEEN) {
-      var value = new BasicDBObject("$gte", asDBValue(expr, 1));
-      value.append("$lte", asDBValue(expr, 2));
-      return asDBObject(asDBKey(expr, 0), value);
+      return asDBObjectOrExpressionBetween(expr);
 
     } else if (op == Ops.IN) {
       var constIndex = 0;
@@ -212,17 +421,7 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
         constIndex = 1;
         exprIndex = 0;
       }
-      if (Collection.class.isAssignableFrom(expr.getArg(constIndex).getType())) {
-        @SuppressWarnings("unchecked") // guarded by previous check
-        Collection<?> values =
-            ((Constant<? extends Collection<?>>) expr.getArg(constIndex)).getConstant();
-        return asDBObject(asDBKey(expr, exprIndex), asDBObject("$in", values.toArray()));
-      } else {
-        Path<?> path = (Path<?>) expr.getArg(exprIndex);
-        Constant<?> constant = (Constant<?>) expr.getArg(constIndex);
-        return asDBObject(asDBKey(expr, exprIndex), convert(path, constant));
-      }
-
+      return asDBObjectOrExpressionIn(expr, exprIndex, constIndex);
     } else if (op == Ops.NOT_IN) {
       var constIndex = 0;
       var exprIndex = 1;
@@ -230,16 +429,7 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
         constIndex = 1;
         exprIndex = 0;
       }
-      if (Collection.class.isAssignableFrom(expr.getArg(constIndex).getType())) {
-        @SuppressWarnings("unchecked") // guarded by previous check
-        Collection<?> values =
-            ((Constant<? extends Collection<?>>) expr.getArg(constIndex)).getConstant();
-        return asDBObject(asDBKey(expr, exprIndex), asDBObject("$nin", values.toArray()));
-      } else {
-        Path<?> path = (Path<?>) expr.getArg(exprIndex);
-        Constant<?> constant = (Constant<?>) expr.getArg(constIndex);
-        return asDBObject(asDBKey(expr, exprIndex), asDBObject("$ne", convert(path, constant)));
-      }
+      return asDBObjectOrExpressionNotIn(expr, exprIndex, constIndex);
 
     } else if (op == Ops.COL_IS_EMPTY) {
       var list = new BasicDBList();
@@ -248,16 +438,15 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
       return asDBObject("$or", list);
 
     } else if (op == Ops.LT) {
-      return asDBObject(asDBKey(expr, 0), asDBObject("$lt", asDBValue(expr, 1)));
+      return asDBObjectOrExpresson("$lt", expr);
 
     } else if (op == Ops.GT) {
-      return asDBObject(asDBKey(expr, 0), asDBObject("$gt", asDBValue(expr, 1)));
+      return asDBObjectOrExpresson("$gt", expr);
 
     } else if (op == Ops.LOE) {
-      return asDBObject(asDBKey(expr, 0), asDBObject("$lte", asDBValue(expr, 1)));
-
+      return asDBObjectOrExpresson("$lte", expr);
     } else if (op == Ops.GOE) {
-      return asDBObject(asDBKey(expr, 0), asDBObject("$gte", asDBValue(expr, 1)));
+      return asDBObjectOrExpresson("$gte", expr);
 
     } else if (op == Ops.IS_NULL) {
       return asDBObject(asDBKey(expr, 0), asDBObject("$exists", false));
@@ -291,8 +480,11 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
       return asDBObject(asDBKey(expr, 0), asDBObject("$all", asDBValue(expr, 1)));
     } else if (op == MongodbOps.ELEM_MATCH) {
       return asDBObject(asDBKey(expr, 0), asDBObject("$elemMatch", asDBValue(expr, 1)));
+    } else if (op == Ops.SET) {
+      return asDbList(expr);
+    } else if (op == Ops.LIST) {
+      return asDbList(expr);
     }
-
     throw new UnsupportedOperationException("Illegal operation " + expr);
   }
 

--- a/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
+++ b/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
@@ -316,8 +316,8 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
     } else if (op == Ops.NE) {
       Path<?> path = (Path<?>) expr.getArg(0);
       Object constant = expr.getArg(1);
-      if (constant instanceof Constant<?> constatntValue) {
-        return asDBObject(asDBKey(expr, 0), asDBObject("$ne", convert(path, constatntValue)));
+      if (constant instanceof Constant<?> constantValue) {
+        return asDBObject(asDBKey(expr, 0), asDBObject("$ne", convert(path, constantValue)));
       } else {
         Object rightField = MONGO_EXPR_SYMBOL + asDBKey(expr, 1);
         Object leftField = MONGO_EXPR_SYMBOL + asDBKey(expr, 0);

--- a/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
+++ b/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/MongodbSerializer.java
@@ -357,9 +357,10 @@ public abstract class MongodbSerializer implements Visitor<Object, Void> {
       }
     } else if (op == Ops.EQ_IGNORE_CASE) {
       if (expr.getArg(1) instanceof Constant<?>) {
-        asDBObject(
+        return asDBObject(
             asDBKey(expr, 0),
             Pattern.compile("^" + regexValue(expr, 1) + "$", Pattern.CASE_INSENSITIVE));
+
       } else {
         return createRegexMatch(expr, true, STRING_MATCH_TYPE.EQUALS);
       }

--- a/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
+++ b/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
@@ -271,8 +271,8 @@ public abstract class MongodbDocumentSerializer implements Visitor<Object, Void>
       } else if (expr.getArg(0) instanceof Path) {
         Path<?> path = (Path<?>) expr.getArg(0);
         Object constant = expr.getArg(1);
-        if (constant instanceof Constant<?> constatntValue) {
-          return asDocument(asDBKey(expr, 0), convert(path, constatntValue));
+        if (constant instanceof Constant<?> constantValue) {
+          return asDocument(asDBKey(expr, 0), convert(path, constantValue));
         } else {
           Object rightField = MONGO_EXPR_SYMBOL + asDBKey(expr, 1);
           Object leftField = MONGO_EXPR_SYMBOL + asDBKey(expr, 0);

--- a/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
+++ b/querydsl-libraries/querydsl-mongodb/src/main/java/com/querydsl/mongodb/document/MongodbDocumentSerializer.java
@@ -330,8 +330,8 @@ public abstract class MongodbDocumentSerializer implements Visitor<Object, Void>
     } else if (op == Ops.NE) {
       Path<?> path = (Path<?>) expr.getArg(0);
       Object constant = expr.getArg(1);
-      if (constant instanceof Constant<?> constatntValue) {
-        return asDocument(asDBKey(expr, 0), asDocument("$ne", convert(path, constatntValue)));
+      if (constant instanceof Constant<?> constantValue) {
+        return asDocument(asDBKey(expr, 0), asDocument("$ne", convert(path, constantValue)));
       } else {
         Object rightField = MONGO_EXPR_SYMBOL + asDBKey(expr, 1);
         Object leftField = MONGO_EXPR_SYMBOL + asDBKey(expr, 0);

--- a/querydsl-libraries/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongoExpressionTest.java
+++ b/querydsl-libraries/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongoExpressionTest.java
@@ -362,7 +362,7 @@ public class MongoExpressionTest {
   }
 
   @Test
-  public void desctription_eq_constant() {
+  public void description_eq_constant() {
     List<Product> results = query().where(product.shotDesc.eq("Lux")).fetch();
     long expected = data.stream().filter(p -> "Lux".equals(p.getShotDesc())).count();
     assertEquals((int) expected, results.size());

--- a/querydsl-libraries/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongoExpressionTest.java
+++ b/querydsl-libraries/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongoExpressionTest.java
@@ -363,7 +363,7 @@ public class MongoExpressionTest {
 
   @Test
   public void desctription_eq_constant() {
-    List<Product> results = query().where(product.description.eq("Lux")).fetch();
+    List<Product> results = query().where(product.shotDesc.eq("Lux")).fetch();
     long expected = data.stream().filter(p -> "Lux".equals(p.getShotDesc())).count();
     assertEquals((int) expected, results.size());
   }

--- a/querydsl-libraries/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongoExpressionTest.java
+++ b/querydsl-libraries/querydsl-mongodb/src/test/java/com/querydsl/mongodb/MongoExpressionTest.java
@@ -1,0 +1,444 @@
+package com.querydsl.mongodb;
+
+import static org.junit.Assert.assertEquals;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.querydsl.core.testutil.MongoDB;
+import com.querydsl.mongodb.domain2.Product;
+import com.querydsl.mongodb.domain2.QProduct;
+import com.querydsl.mongodb.morphia.MorphiaQuery;
+import dev.morphia.Datastore;
+import dev.morphia.Morphia;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(MongoDB.class)
+public class MongoExpressionTest {
+  private final MongoClient mongo;
+  private final Datastore ds;
+  private final String dbname = "testdb";
+  private final QProduct product = QProduct.product;
+
+  private final List<Product> data = new ArrayList<>();
+
+  @SuppressWarnings({"deprecation", "removal"})
+  public MongoExpressionTest() {
+    mongo = MongoClients.create();
+    ds = Morphia.createDatastore(mongo, dbname);
+    ds.getMapper().map(Product.class);
+  }
+
+  @Before
+  public void setUp() {
+    ds.getCollection(Product.class).deleteMany(new org.bson.Document());
+    data.clear();
+    add(new Product(10.0, 2.0, 20.0, 30.0, "Lite", "Light everyday product"));
+    add(new Product(50.0, 0.0, 40.0, 60.0, "Lux", "High-value product with no discount"));
+    add(
+        new Product(
+            5.0, 0.0, 5.0, 10.0, "LiTiny", "Small and inexpensive product, similar to Lite"));
+    add(new Product(15.0, 1.0, 30.0, 40.0, "Mid", "Medium product with a small discount"));
+    add(new Product(60.0, 5.0, 55.0, 70.0, "Prem", "Premium product with discount"));
+    add(new Product(25.0, 10.0, 25.0, 30.0, "MidMax", "Mid-range product with large discount"));
+    add(new Product(35.0, 3.0, 20.0, 35.0, "Univ", "Universal product with medium discount"));
+    add(new Product(1.0, 0.0, 2.0, 5.0, "Mini", "Mini practical product"));
+    add(
+        new Product(
+            100.0, 50.0, 120.0, 150.0, "Luxo", "Luxury product with high price and discount"));
+    add(new Product(80.0, 0.0, 70.0, 90.0, "Large", "Large product with no discount"));
+    add(new Product(9.0, 1.0, 9.0, 10.0, "Tiny", "Tiny product with minimal discount"));
+    add(new Product(11.0, 11.0, 12.0, 15.0, "Full", "Product with full discount"));
+    add(new Product(12.0, 6.0, 12.0, 15.0, "Mod", "Medium product with moderate discount"));
+    add(
+        new Product(
+            49.0, 48.0, 60.0, 70.0, "NearFull", "High-value product with nearly full discount"));
+    add(new Product(40.0, 39.0, 40.0, 50.0, "Almost", "Product almost at maximum discount"));
+    add(new Product(70.0, 0.0, 65.0, 80.0, "LargeX", "Large product variant, no discount"));
+    add(
+        new Product(
+            22.0, 2.0, 21.0, 30.0, "MidLite", "Mid product with slight discount, similar to Lite"));
+    add(
+        new Product(
+            21.0, 2.0, 22.0, 25.0, "MidTiny", "Mid product with slight discount, similar to Tiny"));
+    add(new Product(7.0, 7.0, 8.0, 9.0, "FullMini", "Full discount product in mini size"));
+    add(new Product(3.0, 1.0, 3.0, 4.0, "MiniX", "Mini product variant"));
+    add(
+        new Product(
+            200.0,
+            150.0,
+            250.0,
+            300.0,
+            "LuxMax",
+            "Extremely luxurious product with maximum price"));
+    add(new Product(0.0, 0.0, 1.0, 5.0, "Free", "Almost free product"));
+    add(
+        new Product(
+            18.0,
+            8.0,
+            17.0,
+            20.0,
+            "ModMid",
+            "Medium product with moderate discount, bridging Mod and Mid"));
+    add(
+        new Product(
+            17.0,
+            8.0,
+            18.0,
+            20.0,
+            "ModLite",
+            "Medium product with moderate discount, bridging Mod and Lite"));
+  }
+
+  private void add(Product p) {
+    data.add(p);
+    ds.save(p);
+  }
+
+  // Field-to-field: totalStock <= minStock
+  @Test
+  public void totalStock_loe_minStock_fieldToField() {
+    List<Product> results = query().where(product.totalStock.loe(product.minStock)).fetch();
+    long expected = data.stream().filter(p -> p.getTotalStock() <= p.getMinStock()).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Field-to-field: totalStock < minStock
+  @Test
+  public void totalStock_lt_minStock_fieldToField() {
+    List<Product> results = query().where(product.totalStock.lt(product.minStock)).fetch();
+    long expected = data.stream().filter(p -> p.getTotalStock() < p.getMinStock()).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Field-to-field: totalStock > minStock
+  @Test
+  public void totalStock_gt_minStock_fieldToField() {
+    List<Product> results = query().where(product.totalStock.gt(product.minStock)).fetch();
+    long expected = data.stream().filter(p -> p.getTotalStock() > p.getMinStock()).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Field-to-field: totalStock >= minStock
+  @Test
+  public void totalStock_goe_minStock_fieldToField() {
+    List<Product> results = query().where(product.totalStock.goe(product.minStock)).fetch();
+    long expected = data.stream().filter(p -> p.getTotalStock() >= p.getMinStock()).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Constant: totalStock < 10.0
+  @Test
+  public void totalStock_lt_constant() {
+    double threshold = 10.0;
+    List<Product> results = query().where(product.totalStock.lt(threshold)).fetch();
+    long expected = data.stream().filter(p -> p.getTotalStock() < threshold).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Constant via Java variable: totalStock > threshold
+  @Test
+  public void totalStock_gt_variableConstant() {
+    double threshold = 10.0;
+    List<Product> results = query().where(product.totalStock.gt(threshold)).fetch();
+    long expected = data.stream().filter(p -> p.getTotalStock() > threshold).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Constant: totalStock <= 10.0
+  @Test
+  public void totalStock_loe_constant() {
+    double max = 10.0;
+    List<Product> results = query().where(product.totalStock.loe(max)).fetch();
+    long expected = data.stream().filter(p -> p.getTotalStock() <= max).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Constant via Java variable: totalStock >= minValue
+  @Test
+  public void totalStock_goe_variableConstant() {
+    double minValue = 5.0;
+    List<Product> results = query().where(product.totalStock.goe(minValue)).fetch();
+    long expected = data.stream().filter(p -> p.getTotalStock() >= minValue).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Additional field-to-field sanity: totalStock > reservedStock
+  @Test
+  public void totalStock_gt_reservedStock_fieldToField() {
+    List<Product> results = query().where(product.totalStock.gt(product.reservedStock)).fetch();
+    long expected = data.stream().filter(p -> p.getTotalStock() > p.getReservedStock()).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Constant range: totalStock BETWEEN 5.0 AND 10.0 (inclusive)
+  @Test
+  public void totalStock_between_constants_inclusive() {
+    double lower = 5.0, upper = 10.0;
+    List<Product> results = query().where(product.totalStock.between(lower, upper)).fetch();
+    long expected =
+        data.stream().filter(p -> p.getTotalStock() >= lower && p.getTotalStock() <= upper).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Variable range: totalStock BETWEEN lower AND upper
+  @Test
+  public void totalStock_between_variableBounds() {
+    double lower = 6.0;
+    double upper = 100.0;
+    List<Product> results = query().where(product.totalStock.between(lower, upper)).fetch();
+    long expected =
+        data.stream().filter(p -> p.getTotalStock() >= lower && p.getTotalStock() <= upper).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Dynamic columns (emulated BETWEEN): reservedStock <= minStock <= totalStock
+  @Test
+  public void totalStock_between_dynamicFields_viaComparisons() {
+    List<Product> results =
+        query().where(product.minStock.between(product.reservedStock, product.totalStock)).fetch();
+    long expected =
+        data.stream()
+            .filter(
+                p ->
+                    p.getMinStock() >= p.getReservedStock() && p.getMinStock() <= p.getTotalStock())
+            .count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Constant list: totalStock IN (5.0, 50.0)
+  @Test
+  public void totalStock_in_constants() {
+    Set<Double> values = Set.of(5.0, 50.0);
+    List<Product> results = query().where(product.totalStock.in(values)).fetch();
+    long expected = data.stream().filter(p -> values.contains(p.getTotalStock())).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Variable list: totalStock IN list
+  @Test
+  public void totalStock_in_variableList() {
+    List<Double> values = Arrays.asList(10.0, 15.0);
+    List<Product> results = query().where(product.totalStock.in(values)).fetch();
+    long expected = data.stream().filter(p -> values.contains(p.getTotalStock())).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Constant list: totalStock NOT IN (50.0)
+  @Test
+  public void totalStock_notIn_constants() {
+    Set<Double> exclude = Set.of(50.0);
+    List<Product> results = query().where(product.totalStock.notIn(exclude)).fetch();
+    long expected = data.stream().filter(p -> !exclude.contains(p.getTotalStock())).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  // Variable list: totalStock NOT IN list
+  @Test
+  public void totalStock_notIn_variableList() {
+    List<Double> exclude = Arrays.asList(5.0, 10.0);
+    List<Product> results = query().where(product.totalStock.notIn(exclude)).fetch();
+    long expected = data.stream().filter(p -> !exclude.contains(p.getTotalStock())).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void minStock_in_dynamicFields_viaComparisonsSinge() {
+    List<Product> results = query().where(product.minStock.in(product.reservedStock)).fetch();
+    long expected = data.stream().filter(p -> p.getMinStock() == p.getReservedStock()).count();
+
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void minStock_in_dynamicFields_2() {
+    List<Product> results =
+        query()
+            .where(product.minStock.in(product.reservedStock, product.totalStock, product.maxStock))
+            .fetch();
+    long expected =
+        data.stream()
+            .filter(
+                p ->
+                    p.getMinStock() == p.getReservedStock() || p.getMinStock() == p.getTotalStock())
+            .count();
+
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void minStock_in_dynamicFields_3() {
+    List<Product> results =
+        query()
+            .where(product.minStock.in(product.reservedStock, product.totalStock, product.maxStock))
+            .fetch();
+    long expected =
+        data.stream()
+            .filter(
+                p ->
+                    p.getMinStock() == p.getReservedStock()
+                        || p.getMinStock() == p.getTotalStock()
+                        || p.getMinStock() == p.getMaxStock())
+            .count();
+
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void minStock_notIn() {
+    List<Product> results = query().where(product.minStock.notIn(3, 4, 5)).fetch();
+    long expected =
+        data.stream()
+            .filter(p -> p.getMinStock() != 3 && p.getMinStock() != 4 && p.getMinStock() != 5)
+            .count();
+
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void minStock_ne() {
+    List<Product> results = query().where(product.minStock.ne(3.0)).fetch();
+    long expected = data.stream().filter(p -> p.getMinStock() != 3).count();
+
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void minStock_ne_dynamic() {
+    List<Product> results = query().where(product.minStock.ne(product.maxStock)).fetch();
+    long expected = data.stream().filter(p -> p.getMinStock() != p.getMaxStock()).count();
+
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void minStock_notIn_dynamicFields() {
+    List<Product> results =
+        query()
+            .where(
+                product.minStock.notIn(product.reservedStock, product.totalStock, product.maxStock))
+            .fetch();
+    long expected =
+        data.stream()
+            .filter(
+                p ->
+                    p.getMinStock() != p.getReservedStock()
+                        && p.getMinStock() != p.getTotalStock()
+                        && p.getMinStock() != p.getMaxStock())
+            .count();
+
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void minStock_eq_dynamicField() {
+    List<Product> results = query().where(product.minStock.eq(product.totalStock)).fetch();
+    long expected = data.stream().filter(p -> p.getMinStock() == p.getTotalStock()).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void minStock_or_test() {
+    List<Product> results =
+        query()
+            .where(
+                product
+                    .minStock
+                    .eq(product.totalStock)
+                    .or(product.minStock.eq(product.reservedStock)))
+            .fetch();
+    long expected =
+        data.stream()
+            .filter(
+                p ->
+                    p.getMinStock() == p.getTotalStock() || p.getMinStock() == p.getReservedStock())
+            .count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void desctription_eq_constant() {
+    List<Product> results = query().where(product.description.eq("Lux")).fetch();
+    long expected = data.stream().filter(p -> "Lux".equals(p.getShotDesc())).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void description_eq_variable() {
+    List<Product> results = query().where(product.description.eq(product.shotDesc)).fetch();
+    long expected = data.stream().filter(p -> p.getDescription().equals(p.getShotDesc())).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void description_startWith() {
+    String prefix = "Li";
+    List<Product> results = query().where(product.description.startsWith(prefix)).fetch();
+    long expected = data.stream().filter(p -> p.getDescription().startsWith(prefix)).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void description_startWith_variable() {
+    List<Product> results = query().where(product.description.startsWith(product.shotDesc)).fetch();
+    long expected =
+        data.stream().filter(p -> p.getDescription().startsWith(p.getShotDesc())).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void description_startWith_ignore_variable() {
+    List<Product> results =
+        query().where(product.description.startsWithIgnoreCase(product.shotDesc)).fetch();
+    long expected =
+        data.stream()
+            .filter(p -> p.getDescription().toLowerCase().startsWith(p.getShotDesc().toLowerCase()))
+            .count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void description_contains_variable() {
+    List<Product> results = query().where(product.description.contains(product.shotDesc)).fetch();
+    long expected = data.stream().filter(p -> p.getDescription().contains(p.getShotDesc())).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void description_contains_ignoreCase_variable() {
+    List<Product> results =
+        query().where(product.description.containsIgnoreCase(product.shotDesc)).fetch();
+    long expected =
+        data.stream()
+            .filter(p -> p.getDescription().toLowerCase().contains(p.getShotDesc().toLowerCase()))
+            .count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void description_endWith_variable() {
+    List<Product> results = query().where(product.description.endsWith(product.shotDesc)).fetch();
+    long expected = data.stream().filter(p -> p.getDescription().endsWith(p.getShotDesc())).count();
+    assertEquals((int) expected, results.size());
+  }
+
+  @Test
+  public void description_endWith_ignoreCase_variable() {
+    List<Product> results =
+        query().where(product.description.endsWithIgnoreCase(product.shotDesc)).fetch();
+    long expected =
+        data.stream()
+            .filter(p -> p.getDescription().toLowerCase().endsWith(p.getShotDesc().toLowerCase()))
+            .count();
+    assertEquals((int) expected, results.size());
+  }
+
+  private MorphiaQuery<Product> query() {
+    return new MorphiaQuery<>(ds, product);
+  }
+}

--- a/querydsl-libraries/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain2/Product.java
+++ b/querydsl-libraries/querydsl-mongodb/src/test/java/com/querydsl/mongodb/domain2/Product.java
@@ -1,0 +1,89 @@
+package com.querydsl.mongodb.domain2;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import java.util.UUID;
+
+@Entity
+public class Product {
+  @Id private String id = UUID.randomUUID().toString();
+  private double totalStock;
+  private double reservedStock;
+  private double minStock;
+  private double maxStock;
+  private String shotDesc;
+  private String description;
+
+  public Product() {}
+
+  public Product(
+      double totalStock,
+      double reservedStock,
+      double minStock,
+      double maxStock,
+      String shotDesc,
+      String description) {
+    this.totalStock = totalStock;
+    this.reservedStock = reservedStock;
+    this.minStock = minStock;
+    this.maxStock = maxStock;
+    this.shotDesc = shotDesc;
+    this.description = description;
+  }
+
+  public double getTotalStock() {
+    return totalStock;
+  }
+
+  public void setTotalStock(double totalStock) {
+    this.totalStock = totalStock;
+  }
+
+  public double getReservedStock() {
+    return reservedStock;
+  }
+
+  public void setReservedStock(double reservedStock) {
+    this.reservedStock = reservedStock;
+  }
+
+  public double getMinStock() {
+    return minStock;
+  }
+
+  public void setMinStock(double minStock) {
+    this.minStock = minStock;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public double getMaxStock() {
+    return maxStock;
+  }
+
+  public void setMaxStock(double maxStock) {
+    this.maxStock = maxStock;
+  }
+
+  public String getShotDesc() {
+    return shotDesc;
+  }
+
+  public void setShotDesc(String shotDesc) {
+    this.shotDesc = shotDesc;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+}

--- a/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/MemJavaFileObject.java
+++ b/querydsl-tooling/querydsl-codegen-utils/src/main/java/com/querydsl/codegen/utils/MemJavaFileObject.java
@@ -44,7 +44,7 @@ public class MemJavaFileObject extends SimpleJavaFileObject {
     if (baos == null) {
       throw new FileNotFoundException(name);
     }
-    return new String(baos.toByteArray(), StandardCharsets.UTF_8);
+    return baos.toString(StandardCharsets.UTF_8);
   }
 
   @Override


### PR DESCRIPTION
Refactored:
IN,NOT_IN,
BETWEEN,
EQ,
NE,
LT,
GT,
LOE,
GOE,
IS_NULL,
STARTS_WITH,
STARTS_WITH_IC,
ENDS_WITH,
ENDS_WITH_IC,
EQ_IGNORE_CASE,
STRING_CONTAINS,
STRING_CONTAINS_IC,
CONTAINS, CONTAINS_IC,
MATCHES,MATCHES_IC