### PR TITLE
Fix KSP type extraction for Comparable and Number types with @Convert

### DIFF
--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Invoice.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Invoice.kt
@@ -1,0 +1,23 @@
+package com.querydsl.example.ksp
+
+import jakarta.persistence.Column
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import java.time.YearMonth
+import java.util.UUID
+
+@Entity
+class Invoice(
+    @Id
+    val id: UUID,
+
+    @Column(nullable = false, length = 7)
+    @Convert(converter = YearMonthConverter::class)
+    val month: YearMonth?,
+
+    @Column(nullable = false, precision = 30, scale = 10)
+    @Convert(converter = MoneyConverter::class)
+    val amount: Money?,
+)
+

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Money.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/Money.kt
@@ -1,0 +1,16 @@
+package com.querydsl.example.ksp
+
+import java.math.BigDecimal
+
+data class Money(val value: BigDecimal) : Number(), Comparable<Money> {
+
+    override fun toByte(): Byte = value.toByte()
+    override fun toDouble(): Double = value.toDouble()
+    override fun toFloat(): Float = value.toFloat()
+    override fun toInt(): Int = value.toInt()
+    override fun toLong(): Long = value.toLong()
+    override fun toShort(): Short = value.toShort()
+
+    override fun compareTo(other: Money): Int = this.value.compareTo(other.value)
+}
+

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/MoneyConverter.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/MoneyConverter.kt
@@ -1,0 +1,18 @@
+package com.querydsl.example.ksp
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import java.math.BigDecimal
+
+@Converter
+class MoneyConverter : AttributeConverter<Money, BigDecimal> {
+    
+    override fun convertToDatabaseColumn(attribute: Money?): BigDecimal? {
+        return attribute?.value
+    }
+    
+    override fun convertToEntityAttribute(dbData: BigDecimal?): Money? {
+        return dbData?.let { Money(it) }
+    }
+}
+

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/YearMonthConverter.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/main/kotlin/com/querydsl/example/ksp/YearMonthConverter.kt
@@ -1,0 +1,18 @@
+package com.querydsl.example.ksp
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import java.time.YearMonth
+
+@Converter
+class YearMonthConverter : AttributeConverter<YearMonth, String> {
+    
+    override fun convertToDatabaseColumn(attribute: YearMonth?): String? {
+        return attribute?.toString()
+    }
+    
+    override fun convertToEntityAttribute(dbData: String?): YearMonth? {
+        return dbData?.let { YearMonth.parse(it) }
+    }
+}
+

--- a/querydsl-examples/querydsl-example-ksp-codegen/src/test/kotlin/Tests.kt
+++ b/querydsl-examples/querydsl-example-ksp-codegen/src/test/kotlin/Tests.kt
@@ -9,6 +9,7 @@ import com.querydsl.example.ksp.QBear
 import com.querydsl.example.ksp.QBearSimplifiedProjection
 import com.querydsl.example.ksp.QCat
 import com.querydsl.example.ksp.QDog
+import com.querydsl.example.ksp.QInvoice
 import com.querydsl.example.ksp.QMyShape
 import com.querydsl.example.ksp.QPerson
 import com.querydsl.example.ksp.QPersonClassDTO
@@ -288,6 +289,18 @@ class Tests {
 		val departureProperty = QMyShape::class.memberProperties.single { it.name == "departureGeo" }
 		assertThat(departureProperty.returnType.jvmErasure.qualifiedName!!).isEqualTo("com.querydsl.spatial.locationtech.jts.JTSGeometryPath")
 		assertThat(departureProperty.returnType.arguments.single().type!!.jvmErasure.qualifiedName!!).isEqualTo("org.locationtech.jts.geom.Geometry")
+	}
+
+	@Test
+	fun `Invoice month and amount generate correct path types`() {
+		val monthProperty = QInvoice::class.memberProperties.single { it.name == "month" }
+		val amountProperty = QInvoice::class.memberProperties.single { it.name == "amount" }
+		
+		assertThat(monthProperty.returnType.jvmErasure.qualifiedName!!).isEqualTo("com.querydsl.core.types.dsl.ComparablePath")
+		assertThat(monthProperty.returnType.arguments.single().type!!.jvmErasure.qualifiedName!!).isEqualTo("java.time.YearMonth")
+		
+		assertThat(amountProperty.returnType.jvmErasure.qualifiedName!!).isEqualTo("com.querydsl.core.types.dsl.NumberPath")
+		assertThat(amountProperty.returnType.arguments.single().type!!.jvmErasure.qualifiedName!!).isEqualTo("com.querydsl.example.ksp.Money")
 	}
 
     private fun initialize(): EntityManagerFactory {

--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelExtractor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelExtractor.kt
@@ -90,7 +90,6 @@ class QueryModelExtractor(
                 val extractor = TypeExtractor(
                     settings,
                     "${declaration.parent?.location} - $paramName",
-                    parameter.annotations
                 )
                 val type = extractor.extract(parameter.type.resolve())
                 QProperty(paramName, type)
@@ -109,7 +108,6 @@ class QueryModelExtractor(
                 val extractor = TypeExtractor(
                     settings,
                     property.simpleName.asString(),
-                    property.annotations
                 )
                 val type = extractor.extract(property.type.resolve())
                 QProperty(propName, type)


### PR DESCRIPTION
resolves #1452 

## Additional context

**Root Cause:**

The issue stems from a fundamental difference in how Java APT and KSP code generators handle type extraction:

1. **Java APT behavior**: The APT implementation (`ExtendedTypeFactory`) does not consider the presence of `@Convert` annotations when determining path types. It solely analyzes the declared type's hierarchy (e.g., whether it implements `Comparable` or extends `Number`) to determine the appropriate path type.

2. **KSP behavior (before fix)**: The KSP `TypeExtractor` had a `userType()` method that checked for annotations including `@Convert`, `@Type`, and `@JdbcTypeCode`. When these annotations were present, the method would return `Unknown` type, which was then rendered as `SimplePath<T>`.

3. **Execution order issue**: The `fallbackType()` method in `TypeExtractor` contains logic to check if a type implements `Comparable` or extends `Number`. Additionally, the `referenceType()` method handles enum types by generating `EnumPath<T>`. However, when `@Convert` annotation was present, the `userType()` method was called first in the type extraction chain (before `fallbackType()` and `referenceType()`), causing it to return `Unknown` type immediately. This prevented the type hierarchy analysis in `fallbackType()` and enum detection in `referenceType()` from ever being executed, resulting in:
   - `SimplePath<T>` being generated instead of the correct `ComparablePath<T>` or `NumberPath<T>` for Comparable/Number types
   - `SimplePath<T>` being generated instead of `EnumPath<T>` for enum types with `@Convert` annotation (as documented in [PR #1411](https://github.com/OpenFeign/querydsl/pull/1411))
   
   The removal of the `userType()` method resolves both issues, allowing proper type detection based on type hierarchy and enum identification.

**The Fix:**

The fix removes the annotation-based type detection (`userType()` method) from `TypeExtractor`, allowing the type extraction logic to proceed directly to type hierarchy analysis. This ensures that:
- Types implementing `Comparable` are correctly identified and generate `ComparablePath<T>` (e.g., `YearMonth`)
- Types extending `Number` and implementing `Comparable` are correctly identified and generate `NumberPath<T>` (e.g., `Money`)
- Enum types are correctly identified and generate `EnumPath<T>` (even when `@Convert` annotation is present), enabling enum-specific operations like `coalesce()`
- The behavior matches Java APT implementation, which ignores annotation presence and focuses solely on type structure

**Related Pull Requests:**

- [PR #1263](https://github.com/OpenFeign/querydsl/pull/1263): Added `fallbackType()` method to handle unknown types by checking if they implement `Comparable` (generates `ComparablePath`) or fallback to `SimplePath` otherwise.
- [PR #1127](https://github.com/OpenFeign/querydsl/pull/1127): Modified `userType()` method to support `@JdbcTypeCode` annotation.
- [PR #1411](https://github.com/OpenFeign/querydsl/pull/1411): Fixed enum types with `@Convert` annotation generating `SimplePath` instead of `EnumPath` by removing the `userType()` method that was preventing proper enum detection in `referenceType()`.

