### PR TITLE
add docker-compose.yml force amd64 images for database stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
   mysql:
     image: mysql:5.6.38
+    platform: linux/amd64
     ports:
       - "3306:3306"
     environment:
@@ -22,6 +23,7 @@ services:
 
   postgresql:
     image: postgis/postgis:16-3.4-alpine
+    platform: linux/amd64
     ports:
       - "5432:5432"
     environment:
@@ -31,6 +33,7 @@ services:
 
   oracle:
     image: gvenzl/oracle-xe:slim-faststart
+    platform: linux/amd64
     ports:
       - "1521:1521"
     environment:
@@ -41,6 +44,7 @@ services:
 
   cubrid:
     image: cubrid/cubrid:11.3
+    platform: linux/amd64
     ports:
       - "33000:33000"
       - "30000:30000"
@@ -57,11 +61,13 @@ services:
 
   mongo:
     image: mongo:8.0.9
+    platform: linux/amd64
     ports:
       - "27017:27017"
 
   db2:
     image: ibmcom/db2:11.5.0.0
+    platform: linux/amd64
     privileged: true
     ports:
       - "50000:50000"
@@ -80,6 +86,7 @@ services:
 
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2017-latest-ubuntu
+    platform: linux/amd64
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Password1!
@@ -94,6 +101,7 @@ services:
 
   firebird:
     image: jacobalberty/firebird:v4
+    platform: linux/amd64
     ports:
       - "3050:3050"
     environment:


### PR DESCRIPTION
# Problem

I'm using a Mac in my local environment, but I can't run Docker images. 

# Solution

Add platform-related settings to the docker-compose file to ensure smooth operation in both local and legacy environments.

As far as I know, this file is only used in testing environments and has no impact on the actual project.


Please check it out when you have time. 😀