### PR TITLE
Add sumDouble, sumLong, sumBigDecimal, and sumBigInteger to NumberExpression for forward compatibility with Querydsl 6+

### DIFF
--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
@@ -16,6 +16,8 @@ package com.querydsl.core.types.dsl;
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.Ops.MathOps;
 import com.querydsl.core.util.MathUtils;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.Nullable;
@@ -747,6 +749,14 @@ public abstract class NumberExpression<T extends Number & Comparable<?>>
     return Expressions.numberOperation(getType(), Ops.SUB, mixin, ConstantImpl.create(right));
   }
 
+  @SuppressWarnings("unchecked")
+  private <P extends Number & Comparable<?>> NumberExpression<P> sum(Class<P> clazz) {
+    if (sum == null) {
+      sum = (NumberExpression<T>) Expressions.numberOperation(clazz, Ops.AggOps.SUM_AGG, mixin);
+    }
+    return (NumberExpression<P>) sum;
+  }
+
   /**
    * Create a {@code sum(this)} expression
    *
@@ -754,11 +764,29 @@ public abstract class NumberExpression<T extends Number & Comparable<?>>
    *
    * @return sum(this)
    */
+  @SuppressWarnings("unchecked")
   public NumberExpression<T> sum() {
-    if (sum == null) {
-      sum = Expressions.numberOperation(getType(), Ops.AggOps.SUM_AGG, mixin);
-    }
-    return sum;
+    return sum((Class<T>) getType());
+  }
+
+  /** {@link Float} {@link Double} are mapped to sumDouble. */
+  public NumberExpression<Double> sumDouble() {
+    return sum(Double.class);
+  }
+
+  /** {@link Byte} {@link Short} {@link Integer} {@link Long} are mapped to sumLong. */
+  public NumberExpression<Long> sumLong() {
+    return sum(Long.class);
+  }
+
+  /** {@link java.math.BigDecimal} are mapped to sumBigDecimal. */
+  public NumberExpression<BigDecimal> sumBigDecimal() {
+    return sum(BigDecimal.class);
+  }
+
+  /** {@link java.math.BigInteger} are mapped to sumBigInteger. */
+  public NumberExpression<BigInteger> sumBigInteger() {
+    return sum(BigInteger.class);
   }
 
   @Override

--- a/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
+++ b/querydsl-core/src/main/java/com/querydsl/core/types/dsl/NumberExpression.java
@@ -16,6 +16,8 @@ package com.querydsl.core.types.dsl;
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.Ops.MathOps;
 import com.querydsl.core.util.MathUtils;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.Nullable;
@@ -747,6 +749,14 @@ public abstract class NumberExpression<T extends Number & Comparable<?>>
     return Expressions.numberOperation(getType(), Ops.SUB, mixin, ConstantImpl.create(right));
   }
 
+  @SuppressWarnings("unchecked")
+  private <P extends Number & Comparable<?>> NumberExpression<P> sum(Class<P> clazz) {
+    if (sum == null) {
+      sum = (NumberExpression<T>) Expressions.numberOperation(clazz, Ops.AggOps.SUM_AGG, mixin);
+    }
+    return (NumberExpression<P>) sum;
+  }
+
   /**
    * Create a {@code sum(this)} expression
    *
@@ -755,10 +765,27 @@ public abstract class NumberExpression<T extends Number & Comparable<?>>
    * @return sum(this)
    */
   public NumberExpression<T> sum() {
-    if (sum == null) {
-      sum = Expressions.numberOperation(getType(), Ops.AggOps.SUM_AGG, mixin);
-    }
-    return sum;
+    return sum(getType());
+  }
+
+  /** {@link Float} {@link Double} are mapped to sumDouble. */
+  public NumberExpression<Double> sumDouble() {
+    return sum(Double.class);
+  }
+
+  /** {@link Byte} {@link Short} {@link Integer} {@link Long} are mapped to sumLong. */
+  public NumberExpression<Long> sumLong() {
+    return sum(Long.class);
+  }
+
+  /** {@link java.math.BigDecimal} are mapped to sumBigDecimal. */
+  public NumberExpression<BigDecimal> sumBigDecimal() {
+    return sum(BigDecimal.class);
+  }
+
+  /** {@link java.math.BigInteger} are mapped to sumBigInteger. */
+  public NumberExpression<BigInteger> sumBigInteger() {
+    return sum(BigInteger.class);
   }
 
   @Override

--- a/querydsl-core/src/test/java/com/querydsl/core/types/dsl/NumberExpressionTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/dsl/NumberExpressionTest.java
@@ -15,9 +15,6 @@ package com.querydsl.core.types.dsl;
 
 import static org.junit.Assert.assertEquals;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-
 import org.junit.Test;
 
 public class NumberExpressionTest {
@@ -33,25 +30,4 @@ public class NumberExpressionTest {
   public void between_end_given() {
     assertEquals(intPath.loe(3L), intPath.between(null, 3L));
   }
-
-  @Test
-  public void sumBigDecimal_has_bigDecimal_type() {
-    assertEquals(BigDecimal.class, intPath.sumBigDecimal().getType());
-  }
-
-  @Test
-  public void sumBigInteger_has_bigInteger_type() {
-    assertEquals(BigInteger.class, intPath.sumBigInteger().getType());
-  }
-
-  @Test
-  public void sumDouble_has_double_type() {
-    assertEquals(Double.class, intPath.sumDouble().getType());
-  }
-
-  @Test
-  public void sumLong_has_long_type() {
-    assertEquals(Long.class, intPath.sumLong().getType());
-  }
-
 }

--- a/querydsl-core/src/test/java/com/querydsl/core/types/dsl/NumberExpressionTest.java
+++ b/querydsl-core/src/test/java/com/querydsl/core/types/dsl/NumberExpressionTest.java
@@ -15,6 +15,9 @@ package com.querydsl.core.types.dsl;
 
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import org.junit.Test;
 
 public class NumberExpressionTest {
@@ -30,4 +33,25 @@ public class NumberExpressionTest {
   public void between_end_given() {
     assertEquals(intPath.loe(3L), intPath.between(null, 3L));
   }
+
+  @Test
+  public void sumBigDecimal_has_bigDecimal_type() {
+    assertEquals(BigDecimal.class, intPath.sumBigDecimal().getType());
+  }
+
+  @Test
+  public void sumBigInteger_has_bigInteger_type() {
+    assertEquals(BigInteger.class, intPath.sumBigInteger().getType());
+  }
+
+  @Test
+  public void sumDouble_has_double_type() {
+    assertEquals(Double.class, intPath.sumDouble().getType());
+  }
+
+  @Test
+  public void sumLong_has_long_type() {
+    assertEquals(Long.class, intPath.sumLong().getType());
+  }
+
 }


### PR DESCRIPTION
## Summary

Add the following typed aggregation helpers to `NumberExpression`:

- `sumDouble()`
- `sumLong()`
- `sumBigDecimal()`
- `sumBigInteger()`

## Motivation

Querydsl 6+ introduces typed aggregation helpers such as `sumDouble()` and `sumLong()`.  
Adding these methods to Querydsl 5 allows projects to adopt the newer DSL now and makes future upgrades easier.

This provides **forward compatibility** and reduces code changes required when migrating to newer versions.

## Example

```java
qOrder.amount.sumDouble();
qOrder.quantity.sumLong();
qInvoice.total.sumBigDecimal();