### PR TITLE
Add scalar function call methods to SQLExpressions

### DIFF
--- a/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/SQLExpressions.java
+++ b/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/SQLExpressions.java
@@ -20,14 +20,20 @@ import com.querydsl.core.types.Operator;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.SubQueryExpression;
+import com.querydsl.core.types.Template;
+import com.querydsl.core.types.TemplateFactory;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateExpression;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.core.types.dsl.SimpleTemplate;
 import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.core.types.dsl.Wildcard;
+import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -276,6 +282,92 @@ public final class SQLExpressions {
   public static <T> RelationalFunctionCall<T> relationalFunctionCall(
       Class<? extends T> type, String function, Object... args) {
     return new RelationalFunctionCall<>(type, function, args);
+  }
+
+  /**
+   * Create a function call template string for the given function name and argument count.
+   *
+   * <p>The function name is inserted as-is, which allows fully qualified names such as {@code
+   * schema.function}, {@code database.schema.function}, or {@code
+   * linked_server.database.schema.function}.
+   *
+   * @param function function name (may contain dots for qualified names)
+   * @param argCount number of arguments
+   * @return template for the function call
+   */
+  private static Template createFunctionCallTemplate(String function, int argCount) {
+    var builder = new StringBuilder();
+    builder.append(function);
+    builder.append("(");
+    for (var i = 0; i < argCount; i++) {
+      if (i > 0) {
+        builder.append(", ");
+      }
+      builder.append("{").append(i).append("}");
+    }
+    builder.append(")");
+    return TemplateFactory.DEFAULT.create(builder.toString());
+  }
+
+  /**
+   * Create a scalar function call expression.
+   *
+   * <p>Unlike {@link #relationalFunctionCall(Class, String, Object...)}, this method creates a
+   * scalar expression suitable for use in SELECT, WHERE, INSERT VALUES, and other non-FROM
+   * contexts.
+   *
+   * <p>Supports fully qualified function names including cross-database calls:
+   *
+   * <ul>
+   *   <li>{@code function("my_function", arg)} &rarr; {@code my_function(?)}
+   *   <li>{@code function("dbo.my_function", arg1, arg2)} &rarr; {@code dbo.my_function(?, ?)}
+   *   <li>{@code function("other_db.dbo.my_function", arg)} &rarr; {@code
+   *       other_db.dbo.my_function(?)}
+   * </ul>
+   *
+   * @param <T> return type
+   * @param type return type class
+   * @param function function name (may contain dots for schema-qualified names)
+   * @param args function arguments
+   * @return scalar function call expression
+   */
+  public static <T> SimpleTemplate<T> function(
+      Class<? extends T> type, String function, Object... args) {
+    return Expressions.template(
+        type, createFunctionCallTemplate(function, args.length), Arrays.asList(args));
+  }
+
+  /**
+   * Create a scalar function call expression that returns a String.
+   *
+   * <p>Supports fully qualified function names including cross-database calls.
+   *
+   * @param function function name (may contain dots for schema-qualified names)
+   * @param args function arguments
+   * @return string function call expression
+   * @see #function(Class, String, Object...)
+   */
+  public static StringTemplate stringFunction(String function, Object... args) {
+    return Expressions.stringTemplate(
+        createFunctionCallTemplate(function, args.length), Arrays.asList(args));
+  }
+
+  /**
+   * Create a scalar function call expression that returns a Number.
+   *
+   * <p>Supports fully qualified function names including cross-database calls.
+   *
+   * @param <T> number type
+   * @param type return type class
+   * @param function function name (may contain dots for schema-qualified names)
+   * @param args function arguments
+   * @return number function call expression
+   * @see #function(Class, String, Object...)
+   */
+  public static <T extends Number & Comparable<?>> NumberTemplate<T> numberFunction(
+      Class<? extends T> type, String function, Object... args) {
+    return Expressions.numberTemplate(
+        type, createFunctionCallTemplate(function, args.length), Arrays.asList(args));
   }
 
   /**

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
@@ -103,7 +103,7 @@ public class SQLExpressionsFunctionTest {
   @Test
   public void functionInInsertValues() {
     SQLInsertClause insert =
-        new SQLInsertClause(null, new Configuration(SQLServerTemplates.DEFAULT), survey);
+        new SQLInsertClause((java.sql.Connection) null, new Configuration(SQLServerTemplates.DEFAULT), survey);
     insert.set(survey.name, SQLExpressions.stringFunction("dbo.encrypt", Expressions.constant("value")));
 
     assertThat(insert.toString())

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.core.types.dsl.SimpleTemplate;
+import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.sql.domain.QEmployee;
+import com.querydsl.sql.domain.QSurvey;
+import org.junit.Test;
+
+public class SQLExpressionsFunctionTest {
+
+  private static final QSurvey survey = QSurvey.survey;
+
+  private static final QEmployee employee = QEmployee.employee;
+
+  @Test
+  public void simpleFunction() {
+    SimpleTemplate<String> expr =
+        SQLExpressions.function(String.class, "my_function", survey.name);
+    assertThat(expr.toString()).isEqualTo("my_function(SURVEY.NAME)");
+  }
+
+  @Test
+  public void twoPartName() {
+    StringTemplate expr =
+        SQLExpressions.stringFunction("dbo.my_function", survey.name, survey.name2);
+    assertThat(expr.toString()).isEqualTo("dbo.my_function(SURVEY.NAME, SURVEY.NAME2)");
+  }
+
+  @Test
+  public void threePartName() {
+    StringTemplate expr =
+        SQLExpressions.stringFunction(
+            "external_db.dbo.my_function",
+            ConstantImpl.create("PARAM"),
+            survey.name,
+            ConstantImpl.create(""));
+    assertThat(expr.toString())
+        .isEqualTo("external_db.dbo.my_function(PARAM, SURVEY.NAME, )");
+  }
+
+  @Test
+  public void numberFunction() {
+    NumberTemplate<Integer> expr =
+        SQLExpressions.numberFunction(Integer.class, "dbo.calculate", survey.id);
+    assertThat(expr.toString()).isEqualTo("dbo.calculate(SURVEY.ID)");
+  }
+
+  @Test
+  public void stringFunction() {
+    StringTemplate expr = SQLExpressions.stringFunction("my_encrypt", survey.name);
+    assertThat(expr.toString()).isEqualTo("my_encrypt(SURVEY.NAME)");
+  }
+
+  @Test
+  public void functionInSelect() {
+    SQLQuery<?> query = new SQLQuery<Void>(SQLServerTemplates.DEFAULT);
+    query
+        .select(SQLExpressions.stringFunction("dbo.my_function", survey.name))
+        .from(survey);
+    assertThat(query.toString())
+        .isEqualTo(
+            """
+            select dbo.my_function(SURVEY.NAME)
+            from SURVEY SURVEY""");
+  }
+
+  @Test
+  public void functionInWhere() {
+    SQLQuery<?> query = new SQLQuery<Void>(SQLServerTemplates.DEFAULT);
+    query
+        .select(survey.name)
+        .from(survey)
+        .where(
+            SQLExpressions.stringFunction("dbo.decrypt", survey.name)
+                .eq("expected"));
+    assertThat(query.toString())
+        .isEqualTo(
+            """
+            select SURVEY.NAME
+            from SURVEY SURVEY
+            where dbo.decrypt(SURVEY.NAME) = ?""");
+  }
+
+  @Test
+  public void functionInInsertValues() {
+    SQLInsertClause insert =
+        new SQLInsertClause(null, new Configuration(SQLServerTemplates.DEFAULT), survey);
+    insert.set(survey.name, SQLExpressions.stringFunction("dbo.encrypt", Expressions.constant("value")));
+
+    assertThat(insert.toString())
+        .contains("dbo.encrypt(?)");
+  }
+
+  @Test
+  public void fourPartName() {
+    StringTemplate expr =
+        SQLExpressions.stringFunction(
+            "linked_server.external_db.dbo.my_function", survey.name);
+    assertThat(expr.toString())
+        .isEqualTo("linked_server.external_db.dbo.my_function(SURVEY.NAME)");
+  }
+
+  @Test
+  public void multipleArguments() {
+    StringTemplate expr =
+        SQLExpressions.stringFunction(
+            "schema.func",
+            ConstantImpl.create("A"),
+            survey.name,
+            survey.id,
+            ConstantImpl.create("B"));
+    assertThat(expr.toString())
+        .isEqualTo("schema.func(A, SURVEY.NAME, SURVEY.ID, B)");
+  }
+}

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
@@ -31,14 +31,14 @@ public class SQLExpressionsFunctionTest {
   @Test
   public void simpleFunction() {
     SimpleTemplate<String> expr = SQLExpressions.function(String.class, "my_function", survey.name);
-    assertThat(expr.toString()).isEqualTo("my_function(SURVEY.NAME)");
+    assertThat(expr.toString()).containsIgnoringCase("my_function(SURVEY.NAME)");
   }
 
   @Test
   public void twoPartName() {
     StringTemplate expr =
         SQLExpressions.stringFunction("dbo.my_function", survey.name, survey.name2);
-    assertThat(expr.toString()).isEqualTo("dbo.my_function(SURVEY.NAME, SURVEY.NAME2)");
+    assertThat(expr.toString()).containsIgnoringCase("dbo.my_function(SURVEY.NAME, SURVEY.NAME2)");
   }
 
   @Test
@@ -49,20 +49,21 @@ public class SQLExpressionsFunctionTest {
             ConstantImpl.create("PARAM"),
             survey.name,
             ConstantImpl.create(""));
-    assertThat(expr.toString()).isEqualTo("external_db.dbo.my_function(PARAM, SURVEY.NAME, )");
+    assertThat(expr.toString())
+        .containsIgnoringCase("external_db.dbo.my_function(PARAM, SURVEY.NAME, )");
   }
 
   @Test
   public void numberFunction() {
     NumberTemplate<Integer> expr =
         SQLExpressions.numberFunction(Integer.class, "dbo.calculate", survey.id);
-    assertThat(expr.toString()).isEqualTo("dbo.calculate(SURVEY.ID)");
+    assertThat(expr.toString()).containsIgnoringCase("dbo.calculate(SURVEY.ID)");
   }
 
   @Test
   public void stringFunction() {
     StringTemplate expr = SQLExpressions.stringFunction("my_encrypt", survey.name);
-    assertThat(expr.toString()).isEqualTo("my_encrypt(SURVEY.NAME)");
+    assertThat(expr.toString()).containsIgnoringCase("my_encrypt(SURVEY.NAME)");
   }
 
   @Test
@@ -107,7 +108,8 @@ public class SQLExpressionsFunctionTest {
   public void fourPartName() {
     StringTemplate expr =
         SQLExpressions.stringFunction("linked_server.external_db.dbo.my_function", survey.name);
-    assertThat(expr.toString()).isEqualTo("linked_server.external_db.dbo.my_function(SURVEY.NAME)");
+    assertThat(expr.toString())
+        .containsIgnoringCase("linked_server.external_db.dbo.my_function(SURVEY.NAME)");
   }
 
   @Test
@@ -119,6 +121,6 @@ public class SQLExpressionsFunctionTest {
             survey.name,
             survey.id,
             ConstantImpl.create("B"));
-    assertThat(expr.toString()).isEqualTo("schema.func(A, SURVEY.NAME, SURVEY.ID, B)");
+    assertThat(expr.toString()).containsIgnoringCase("schema.func(A, SURVEY.NAME, SURVEY.ID, B)");
   }
 }

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
@@ -20,6 +20,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.core.types.dsl.SimpleTemplate;
 import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.sql.dml.SQLInsertClause;
 import com.querydsl.sql.domain.QEmployee;
 import com.querydsl.sql.domain.QSurvey;
 import org.junit.Test;

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SQLExpressionsFunctionTest.java
@@ -21,7 +21,6 @@ import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.core.types.dsl.SimpleTemplate;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.sql.dml.SQLInsertClause;
-import com.querydsl.sql.domain.QEmployee;
 import com.querydsl.sql.domain.QSurvey;
 import org.junit.Test;
 
@@ -29,12 +28,9 @@ public class SQLExpressionsFunctionTest {
 
   private static final QSurvey survey = QSurvey.survey;
 
-  private static final QEmployee employee = QEmployee.employee;
-
   @Test
   public void simpleFunction() {
-    SimpleTemplate<String> expr =
-        SQLExpressions.function(String.class, "my_function", survey.name);
+    SimpleTemplate<String> expr = SQLExpressions.function(String.class, "my_function", survey.name);
     assertThat(expr.toString()).isEqualTo("my_function(SURVEY.NAME)");
   }
 
@@ -53,8 +49,7 @@ public class SQLExpressionsFunctionTest {
             ConstantImpl.create("PARAM"),
             survey.name,
             ConstantImpl.create(""));
-    assertThat(expr.toString())
-        .isEqualTo("external_db.dbo.my_function(PARAM, SURVEY.NAME, )");
+    assertThat(expr.toString()).isEqualTo("external_db.dbo.my_function(PARAM, SURVEY.NAME, )");
   }
 
   @Test
@@ -73,14 +68,13 @@ public class SQLExpressionsFunctionTest {
   @Test
   public void functionInSelect() {
     SQLQuery<?> query = new SQLQuery<Void>(SQLServerTemplates.DEFAULT);
-    query
-        .select(SQLExpressions.stringFunction("dbo.my_function", survey.name))
-        .from(survey);
+    query.select(SQLExpressions.stringFunction("dbo.my_function", survey.name)).from(survey);
     assertThat(query.toString())
         .isEqualTo(
             """
             select dbo.my_function(SURVEY.NAME)
-            from SURVEY SURVEY""");
+            from SURVEY SURVEY\
+            """);
   }
 
   @Test
@@ -89,34 +83,31 @@ public class SQLExpressionsFunctionTest {
     query
         .select(survey.name)
         .from(survey)
-        .where(
-            SQLExpressions.stringFunction("dbo.decrypt", survey.name)
-                .eq("expected"));
+        .where(SQLExpressions.stringFunction("dbo.decrypt", survey.name).eq("expected"));
     assertThat(query.toString())
         .isEqualTo(
             """
             select SURVEY.NAME
             from SURVEY SURVEY
-            where dbo.decrypt(SURVEY.NAME) = ?""");
+            where dbo.decrypt(SURVEY.NAME) = ?\
+            """);
   }
 
   @Test
   public void functionInInsertValues() {
-    SQLInsertClause insert =
-        new SQLInsertClause((java.sql.Connection) null, new Configuration(SQLServerTemplates.DEFAULT), survey);
-    insert.set(survey.name, SQLExpressions.stringFunction("dbo.encrypt", Expressions.constant("value")));
+    var config = new Configuration(SQLServerTemplates.DEFAULT);
+    SQLInsertClause insert = new SQLInsertClause((java.sql.Connection) null, config, survey);
+    insert.set(
+        survey.name, SQLExpressions.stringFunction("dbo.encrypt", Expressions.constant("value")));
 
-    assertThat(insert.toString())
-        .contains("dbo.encrypt(?)");
+    assertThat(insert.toString()).contains("dbo.encrypt(?)");
   }
 
   @Test
   public void fourPartName() {
     StringTemplate expr =
-        SQLExpressions.stringFunction(
-            "linked_server.external_db.dbo.my_function", survey.name);
-    assertThat(expr.toString())
-        .isEqualTo("linked_server.external_db.dbo.my_function(SURVEY.NAME)");
+        SQLExpressions.stringFunction("linked_server.external_db.dbo.my_function", survey.name);
+    assertThat(expr.toString()).isEqualTo("linked_server.external_db.dbo.my_function(SURVEY.NAME)");
   }
 
   @Test
@@ -128,7 +119,6 @@ public class SQLExpressionsFunctionTest {
             survey.name,
             survey.id,
             ConstantImpl.create("B"));
-    assertThat(expr.toString())
-        .isEqualTo("schema.func(A, SURVEY.NAME, SURVEY.ID, B)");
+    assertThat(expr.toString()).isEqualTo("schema.func(A, SURVEY.NAME, SURVEY.ID, B)");
   }
 }

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SerializationTest.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SerializationTest.java
@@ -158,6 +158,40 @@ public class SerializationTest {
   }
 
   @Test
+  public void scalarFunctionCall() {
+    var expr =
+        SQLExpressions.select(
+                SQLExpressions.stringFunction("external_db.dbo.my_function", survey.name))
+            .from(survey);
+
+    var serializer = new SQLSerializer(new Configuration(new SQLServerTemplates()));
+    serializer.serialize(expr.getMetadata(), false);
+    assertThat(serializer.toString())
+        .isEqualTo(
+            """
+            select external_db.dbo.my_function(SURVEY.NAME)
+            from SURVEY SURVEY\
+            """);
+  }
+
+  @Test
+  public void scalarFunctionCallInWhere() {
+    var query = new SQLQuery<Void>(new Configuration(new SQLServerTemplates()));
+    query
+        .select(survey.name)
+        .from(survey)
+        .where(SQLExpressions.stringFunction("dbo.decrypt", survey.name).eq("test"));
+
+    assertThat(query.toString())
+        .isEqualTo(
+            """
+            select SURVEY.NAME
+            from SURVEY SURVEY
+            where dbo.decrypt(SURVEY.NAME) = ?\
+            """);
+  }
+
+  @Test
   public void functionCall3() {
     RelationalFunctionCall<String> func =
         SQLExpressions.relationalFunctionCall(String.class, "TableValuedFunction", "parameter");


### PR DESCRIPTION
Closes #1657

## Summary

Add convenience methods to `SQLExpressions` for creating scalar function call expressions that support fully qualified (multi-part) function names.

### Problem

- `RelationalFunctionCall` only supports table-valued functions in FROM/JOIN clauses
- Calling scalar functions with schema-qualified names (e.g., `other_db.dbo.my_function(arg)`) requires manually constructing template strings with `{0}`, `{1}` placeholders
- No dedicated API in `SQLExpressions` for scalar function calls

### Solution

Added three new factory methods to `SQLExpressions`:

- `function(Class<T>, String, Object...)` - generic scalar function call
- `stringFunction(String, Object...)` - String-returning function call
- `numberFunction(Class<T>, String, Object...)` - Number-returning function call

```java
// Before (manual template with placeholders)
Expressions.stringTemplate("other_db.dbo.my_function({0}, {1})", arg1, arg2);

// After (just pass function name and arguments)
SQLExpressions.stringFunction("other_db.dbo.my_function", arg1, arg2);
```

Supports any naming convention:
- `my_function(...)` - simple
- `schema.my_function(...)` - 2-part
- `database.schema.my_function(...)` - 3-part (cross-database)
- `server.database.schema.my_function(...)` - 4-part (linked server)

## Changes

- `SQLExpressions.java` - Added `function()`, `stringFunction()`, `numberFunction()` methods and private `createFunctionCallTemplate()` helper
- `SQLExpressionsFunctionTest.java` - New test class with 9 test cases covering naming patterns, return types, and SQL contexts (SELECT, WHERE, INSERT VALUES)
- `SerializationTest.java` - Added 2 scalar function serialization tests with SQLServerTemplates