### PR TITLE
fix(ksp): skip parameterized supertypes in TypeExtractor.fallbackType()

### DIFF
--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/TypeExtractor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/TypeExtractor.kt
@@ -65,8 +65,9 @@ class TypeExtractor(
                 Comparable::class.java.canonicalName,
                 java.lang.Comparable::class.qualifiedName
             )
-            declaration.getAllSuperTypes().any {
-                comparableNames.contains(it.toClassName().canonicalName)
+            declaration.getAllSuperTypes().any { supertype ->
+                // Skip parameterized types (e.g. Comparable<ObjectId>) — toClassName() throws for them
+                supertype.arguments.isEmpty() && comparableNames.contains(supertype.toClassName().canonicalName)
             }
         } else {
             false


### PR DESCRIPTION
## Problem
TypeExtractor.fallbackType() crashes with `IllegalStateException` when processing MongoDB `@Document` classes with `ObjectId` fields. The function was calling `toClassName()` on parameterized supertypes like `Comparable<ObjectId>`, which throws an exception because KotlinPoet's `toClassName()` doesn't support parameterized types.

## Solution
Added a guard to check `supertype.arguments.isEmpty()` before calling `toClassName()` in the Comparable check. This skips parameterized supertypes like `Comparable<ObjectId>` which cannot be converted.

## Changes
- **File**: `querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/TypeExtractor.kt`
- **Change**: Added `supertype.arguments.isEmpty() &&` guard in fallbackType() method

## Testing
- All 10 existing tests in querydsl-ksp-codegen pass
- Minimal one-line change, no API changes or breaking changes
- Backward compatible

Fixes #1688