### PR TITLE
Deduplicate fetch join results at QueryDSL level

### DIFF
--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/AbstractHibernateQuery.java
@@ -30,9 +30,12 @@ import com.querydsl.core.types.SubQueryExpression;
 import com.querydsl.jpa.FactoryExpressionTransformer;
 import com.querydsl.jpa.HQLTemplates;
 import com.querydsl.jpa.JPAQueryBase;
+import com.querydsl.jpa.JPAQueryMixin;
 import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.ScrollableResultsIterator;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -213,7 +216,11 @@ public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery
   @SuppressWarnings("unchecked")
   public List<T> fetch() {
     try {
-      return createQuery().list();
+      List<T> results = createQuery().list();
+      if (hasFetchJoin()) {
+        results = new ArrayList<>(new LinkedHashSet<>(results));
+      }
+      return results;
     } finally {
       reset();
     }
@@ -230,6 +237,9 @@ public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery
         var query = createQuery(modifiers, false);
         @SuppressWarnings("unchecked")
         List<T> list = query.list();
+        if (hasFetchJoin()) {
+          list = new ArrayList<>(new LinkedHashSet<>(list));
+        }
         return new QueryResults<>(list, modifiers, total);
       } else {
         return QueryResults.emptyResults();
@@ -237,6 +247,16 @@ public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery
     } finally {
       reset();
     }
+  }
+
+  /**
+   * Check if any join in this query has a fetch join flag.
+   *
+   * @return true if at least one join uses fetchJoin
+   */
+  private boolean hasFetchJoin() {
+    return getMetadata().getJoins().stream()
+        .anyMatch(join -> join.getFlags().contains(JPAQueryMixin.FETCH));
   }
 
   protected void logQuery(String queryString) {
@@ -363,6 +383,17 @@ public abstract class AbstractHibernateQuery<T, Q extends AbstractHibernateQuery
     try {
       var modifiers = getMetadata().getModifiers();
       var query = createQuery(modifiers, false);
+      if (hasFetchJoin()) {
+        List<T> results = query.list();
+        results = new ArrayList<>(new LinkedHashSet<>(results));
+        if (results.isEmpty()) {
+          return null;
+        } else if (results.size() == 1) {
+          return results.get(0);
+        } else {
+          throw new NonUniqueResultException();
+        }
+      }
       try {
         return (T) query.uniqueResult();
       } catch (org.hibernate.NonUniqueResultException e) {

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/AbstractJPAQuery.java
@@ -22,6 +22,7 @@ import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.FactoryExpression;
 import com.querydsl.jpa.JPAQueryBase;
+import com.querydsl.jpa.JPAQueryMixin;
 import com.querydsl.jpa.JPQLSerializer;
 import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.QueryHandler;
@@ -179,10 +180,11 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>>
    */
   private List<?> getResultList(Query query) {
     // TODO : use lazy fetch here?
+    List<?> results;
     if (projection != null) {
-      List<?> results = query.getResultList();
-      List<Object> rv = new ArrayList<>(results.size());
-      for (Object o : results) {
+      List<?> raw = query.getResultList();
+      List<Object> rv = new ArrayList<>(raw.size());
+      for (Object o : raw) {
         if (o != null) {
           if (!o.getClass().isArray()) {
             o = new Object[] {o};
@@ -192,10 +194,29 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>>
           rv.add(projection.newInstance(new Object[] {null}));
         }
       }
-      return rv;
+      results = rv;
     } else {
-      return query.getResultList();
+      results = query.getResultList();
     }
+
+    // Deduplicate results when fetchJoin is used.
+    // Since Hibernate 6, automatic deduplication on fetch joins was removed,
+    // so we handle it at the QueryDSL level for all JPA providers.
+    if (hasFetchJoin()) {
+      results = new ArrayList<>(new LinkedHashSet<>(results));
+    }
+
+    return results;
+  }
+
+  /**
+   * Check if any join in this query has a fetch join flag.
+   *
+   * @return true if at least one join uses fetchJoin
+   */
+  private boolean hasFetchJoin() {
+    return getMetadata().getJoins().stream()
+        .anyMatch(join -> join.getFlags().contains(JPAQueryMixin.FETCH));
   }
 
   /**
@@ -336,6 +357,19 @@ public abstract class AbstractJPAQuery<T, Q extends AbstractJPAQuery<T, Q>>
   @Override
   public T fetchOne() throws NonUniqueResultException {
     try {
+      if (hasFetchJoin()) {
+        // When fetchJoin is used, use getResultList with deduplication
+        // to avoid NonUniqueResultException caused by JOIN duplicates
+        var query = createQuery(getMetadata().getModifiers(), false);
+        var results = (List<T>) getResultList(query);
+        if (results.isEmpty()) {
+          return null;
+        } else if (results.size() == 1) {
+          return results.get(0);
+        } else {
+          throw new NonUniqueResultException();
+        }
+      }
       var query = createQuery(getMetadata().getModifiers(), false);
       return (T) getSingleResult(query);
     } catch (jakarta.persistence.NoResultException e) {


### PR DESCRIPTION
## Summary

- Deduplicate results in `fetch()`, `fetchOne()`, and `fetchResults()` when `fetchJoin()` is used
- Applied in both `AbstractJPAQuery` (JPA) and `AbstractHibernateQuery` (Hibernate)
- Works across all JPA providers — no Hibernate-specific API dependency

Closes #1596

## Problem

Since Hibernate 6, automatic result deduplication for fetch joins was removed, and Hibernate 7.3 fully removed the feature. This causes:

- `fetch()` returning duplicate parent entities from JOIN results
- `fetchOne()` throwing `NonUniqueResultException` when only one entity was expected

## Solution

QueryDSL already knows when `fetchJoin()` is called (via `JoinFlag.FETCH` in query metadata). When detected, results are deduplicated using `LinkedHashSet` (preserves order) before returning.

This is applied at the QueryDSL level rather than using Hibernate's `ResultListTransformer` because:

- `ResultListTransformer.uniqueResultTransformer()` is Hibernate 7.3+ only
- A QueryDSL-level fix works across all JPA providers
- Normal queries without fetchJoin are unaffected

## Test plan

- [x] Existing tests pass (`./mvnw -Pno-databases verify`)
- [x] No behavioral change for queries without fetchJoin
- [x] Code formatted (pre-commit hook)