### PR TITLE
Fix invalid JPQL emitted by JPAInsertClause set() style (#1718)

### DIFF
--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JPQLSerializer.java
@@ -321,16 +321,17 @@ public class JPQLSerializer extends SerializerBase<JPQLSerializer> {
       }
       append(")");
     } else if (inserts != null && !inserts.isEmpty()) {
+      append(VALUES);
+      append(" (");
       first = true;
       for (Map.Entry<Path<?>, Expression<?>> entry : inserts.entrySet()) {
         if (!first) {
           append(", ");
         }
-        handle(entry.getKey());
-        append(" = ");
         handle(entry.getValue());
         first = false;
       }
+      append(")");
     } else {
       serialize(query.getMetadata(), false, null);
     }

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPQLSerializerTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPQLSerializerTest.java
@@ -20,6 +20,7 @@ import com.querydsl.core.DefaultQueryMetadata;
 import com.querydsl.core.JoinType;
 import com.querydsl.core.QueryMetadata;
 import com.querydsl.core.domain.QCat;
+import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;
@@ -28,6 +29,9 @@ import com.querydsl.core.types.SubQueryExpression;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.domain.*;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.Test;
 
 public class JPQLSerializerTest {
@@ -603,5 +607,47 @@ public class JPQLSerializerTest {
     assertThat(hqlSerializer.getConstants()).hasSize(2);
     assertThat(hqlSerializer.getConstants().get(0)).isEqualTo(1);
     assertThat(hqlSerializer.getConstants().get(1)).isEqualTo(2);
+  }
+
+  @Test
+  public void serializeForInsert_setStyle_emitsValuesForm() {
+    var cat = QCat.cat;
+    QueryMetadata md = new DefaultQueryMetadata();
+    md.addJoin(JoinType.DEFAULT, cat);
+
+    Map<Path<?>, Expression<?>> inserts = new LinkedHashMap<>();
+    inserts.put(cat.name, ConstantImpl.create("Bobby"));
+    inserts.put(cat.alive, ConstantImpl.create(false));
+
+    var serializer = new JPQLSerializer(HQLTemplates.DEFAULT);
+    serializer.serializeForInsert(md, inserts.keySet(), Collections.emptyList(), null, inserts);
+
+    var sql = serializer.toString();
+    assertThat(sql).startsWith("insert into Cat (name, alive)");
+    assertThat(sql).contains("\nvalues ");
+    assertThat(sql).endsWith("(?1, ?2)");
+    assertThat(sql).doesNotContain(" = ");
+    assertThat(serializer.getConstants()).containsExactly("Bobby", false);
+  }
+
+  @Test
+  public void serializeForInsert_columnsValuesStyle_unchanged() {
+    var cat = QCat.cat;
+    QueryMetadata md = new DefaultQueryMetadata();
+    md.addJoin(JoinType.DEFAULT, cat);
+
+    var serializer = new JPQLSerializer(HQLTemplates.DEFAULT);
+    serializer.serializeForInsert(
+        md,
+        Arrays.asList(cat.name, cat.alive),
+        Arrays.asList("Bobby", false),
+        null,
+        Collections.emptyMap());
+
+    var sql = serializer.toString();
+    assertThat(sql).startsWith("insert into Cat (name, alive)");
+    assertThat(sql).contains("\nvalues ");
+    assertThat(sql).endsWith("(?1, ?2)");
+    assertThat(serializer.getConstants()).containsExactly("Bobby", false);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1718. `JPAInsertClause`/`HibernateInsertClause` `.set(path, value)` calls were producing invalid JPQL (`path = value` pairs after the column list) which Hibernate rejected with `SyntaxException`. The serializer now emits a proper `VALUES (...)` clause for the `inserts` map, matching the existing column list order (`LinkedHashMap`).

## Before

```
insert into Cat (name, alive)
cat.name = ?1, cat.alive = ?2
```

→ `org.hibernate.query.SyntaxException: At 2:0 and token 'cat', mismatched input 'cat', expecting one of the following tokens: '(', FROM, ORDER, SELECT, VALUES, WHERE, WITH`

## After

```
insert into Cat (name, alive)
values (?1, ?2)
```

## Scope

- `JPQLSerializer.serializeForInsert` — converts the `inserts` map to a `VALUES` list instead of `path = value` pairs
- `columns().values()` style and `INSERT ... SELECT` (sub-query) paths are unchanged

## Test plan

- [x] New unit tests in `JPQLSerializerTest`:
  - `serializeForInsert_setStyle_emitsValuesForm` — verifies `set()`-style now emits `VALUES (...)` and no `path = value`
  - `serializeForInsert_columnsValuesStyle_unchanged` — guards the `columns().values()` path
- [x] `./mvnw -pl querydsl-libraries/querydsl-jpa -Pno-databases test` — 368 tests pass