### PR TITLE
feat(apt): detect circular Q-class references and warn at compile time

### DIFF
--- a/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
+++ b/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
@@ -212,6 +212,14 @@ public abstract class AbstractQuerydslProcessor extends AbstractProcessor {
     // extend entity types
     typeFactory.extendTypes();
 
+    if (!context.entityTypes.isEmpty()) {
+      var serializerConfig =
+          conf.getSerializerConfig(context.entityTypes.values().iterator().next());
+      if (serializerConfig.createDefaultVariable()) {
+        detectCircularQClassReferences();
+      }
+    }
+
     context.clean();
   }
 
@@ -680,6 +688,71 @@ public abstract class AbstractQuerydslProcessor extends AbstractProcessor {
         processingEnv.getMessager().printMessage(Kind.ERROR, e.getMessage());
       }
     }
+  }
+
+  private void detectCircularQClassReferences() {
+    Map<String, EntityType> typeMap = context.entityTypes;
+
+    List<String> detectedCycles = new ArrayList<>();
+    Set<String> globalVisited = new HashSet<>();
+
+    for (EntityType start : typeMap.values()) {
+      if (globalVisited.contains(start.getFullName())) continue;
+
+      Deque<String> path = new ArrayDeque<>();
+      Set<String> inStack = new HashSet<>();
+      dfs(start, typeMap, path, inStack, globalVisited, detectedCycles);
+    }
+
+    if (!detectedCycles.isEmpty()) {
+      var message = new StringBuilder();
+      message.append("[QueryDSL] Circular Q-class references detected.\n");
+      message.append(
+          "This may cause class initialization deadlock in multi-threaded environments.\n\n");
+      message.append("Detected cycles:\n");
+      for (int i = 0; i < detectedCycles.size(); i++) {
+        message.append("  (").append(i + 1).append(") ").append(detectedCycles.get(i)).append("\n");
+      }
+      message.append("\nTo avoid deadlock, consider:\n");
+      message.append("  (1) Removing the bidirectional association on one side.\n");
+      message.append(
+          "  (2) Pre-initializing Q-classes in a single thread before handling requests (e.g. via @PostConstruct).\n");
+      message.append(
+          "  (3) Using 'new QClass(\"alias\")' instead of static field access in your repositories.");
+
+      processingEnv.getMessager().printMessage(Kind.WARNING, message.toString());
+    }
+  }
+
+  private void dfs(
+      EntityType current,
+      Map<String, EntityType> typeMap,
+      Deque<String> path,
+      Set<String> inStack,
+      Set<String> globalVisited,
+      List<String> detectedCycles) {
+
+    String currentName = current.getFullName();
+    globalVisited.add(currentName);
+    inStack.add(currentName);
+    path.addLast(current.getSimpleName());
+
+    for (Property property : current.getProperties()) {
+      String neighborName = property.getType().getFullName();
+      EntityType neighbor = typeMap.get(neighborName);
+      if (neighbor == null) continue;
+
+      if (inStack.contains(neighborName)) {
+        List<String> cycle = new ArrayList<>(path);
+        cycle.add(neighbor.getSimpleName());
+        detectedCycles.add(String.join(" → ", cycle));
+      } else if (!globalVisited.contains(neighborName)) {
+        dfs(neighbor, typeMap, path, inStack, globalVisited, detectedCycles);
+      }
+    }
+
+    path.removeLast();
+    inStack.remove(currentName);
   }
 
   protected String getClassName(EntityType model) {

--- a/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/QuerydslAnnotationProcessorCompileTest.java
+++ b/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/QuerydslAnnotationProcessorCompileTest.java
@@ -130,6 +130,179 @@ class QuerydslAnnotationProcessorCompileTest {
   }
 
   @Test
+  void circularQClassReference_producesWarning() {
+    JavaFileObject orderSource =
+        JavaFileObjects.forSourceString(
+            "test.Order",
+            """
+            package test;
+
+            import com.querydsl.core.annotations.QueryEntity;
+
+            @QueryEntity
+            public class Order {
+              public Customer customer;
+            }
+            """);
+
+    JavaFileObject customerSource =
+        JavaFileObjects.forSourceString(
+            "test.Customer",
+            """
+            package test;
+
+            import com.querydsl.core.annotations.QueryEntity;
+
+            @QueryEntity
+            public class Customer {
+              public Order lastOrder;
+            }
+            """);
+
+    Compilation compilation =
+        javac()
+            .withProcessors(new QuerydslAnnotationProcessor())
+            .compile(orderSource, customerSource);
+
+    CompilationSubject.assertThat(compilation).succeeded();
+    CompilationSubject.assertThat(compilation)
+        .hadWarningContaining("Circular Q-class references detected");
+  }
+
+  @Test
+  void unidirectionalReference_noWarning() {
+    JavaFileObject orderSource =
+        JavaFileObjects.forSourceString(
+            "test.Order",
+            """
+            package test;
+
+            import com.querydsl.core.annotations.QueryEntity;
+
+            @QueryEntity
+            public class Order {
+              public Customer customer;
+            }
+            """);
+
+    JavaFileObject customerSource =
+        JavaFileObjects.forSourceString(
+            "test.Customer",
+            """
+            package test;
+
+            import com.querydsl.core.annotations.QueryEntity;
+
+            @QueryEntity
+            public class Customer {
+              public String name;
+            }
+            """);
+
+    Compilation compilation =
+        javac()
+            .withProcessors(new QuerydslAnnotationProcessor())
+            .compile(orderSource, customerSource);
+
+    CompilationSubject.assertThat(compilation).succeeded();
+    CompilationSubject.assertThat(compilation).hadWarningCount(0);
+  }
+
+  @Test
+  void collectionReference_noWarning() {
+    JavaFileObject orderSource =
+        JavaFileObjects.forSourceString(
+            "test.Order",
+            """
+            package test;
+
+            import com.querydsl.core.annotations.QueryEntity;
+            import java.util.List;
+
+            @QueryEntity
+            public class Order {
+              public List<OrderItem> items;
+            }
+            """);
+
+    JavaFileObject orderItemSource =
+        JavaFileObjects.forSourceString(
+            "test.OrderItem",
+            """
+            package test;
+
+            import com.querydsl.core.annotations.QueryEntity;
+
+            @QueryEntity
+            public class OrderItem {
+              public Order order;
+            }
+            """);
+
+    Compilation compilation =
+        javac()
+            .withProcessors(new QuerydslAnnotationProcessor())
+            .compile(orderSource, orderItemSource);
+
+    CompilationSubject.assertThat(compilation).succeeded();
+    CompilationSubject.assertThat(compilation).hadWarningCount(0);
+  }
+
+  @Test
+  void indirectCircularReference_producesWarning() {
+    JavaFileObject aSource =
+        JavaFileObjects.forSourceString(
+            "test.EntityA",
+            """
+            package test;
+
+            import com.querydsl.core.annotations.QueryEntity;
+
+            @QueryEntity
+            public class EntityA {
+              public EntityB b;
+            }
+            """);
+
+    JavaFileObject bSource =
+        JavaFileObjects.forSourceString(
+            "test.EntityB",
+            """
+            package test;
+
+            import com.querydsl.core.annotations.QueryEntity;
+
+            @QueryEntity
+            public class EntityB {
+              public EntityC c;
+            }
+            """);
+
+    JavaFileObject cSource =
+        JavaFileObjects.forSourceString(
+            "test.EntityC",
+            """
+            package test;
+
+            import com.querydsl.core.annotations.QueryEntity;
+
+            @QueryEntity
+            public class EntityC {
+              public EntityA a;
+            }
+            """);
+
+    Compilation compilation =
+        javac()
+            .withProcessors(new QuerydslAnnotationProcessor())
+            .compile(aSource, bSource, cSource);
+
+    CompilationSubject.assertThat(compilation).succeeded();
+    CompilationSubject.assertThat(compilation)
+        .hadWarningContaining("Circular Q-class references detected");
+  }
+
+  @Test
   void entityWithInheritance_generatesQClasses() {
     JavaFileObject superSource =
         JavaFileObjects.forSourceString(


### PR DESCRIPTION
**Problem Description**

When two JPA entities have a bidirectional association (e.g., `@OneToOne`), QueryDSL APT generates Q-classes that contain circular static field references. If two threads simultaneously access these Q-classes for the first time, a class initialization deadlock occurs — all worker threads hang indefinitely without any exceptions or error logs.

This issue has been a long-standing pain point since 2012 ([querydsl/querydsl#146](https://github.com/querydsl/querydsl/issues/146)) and 2018 ([querydsl/querydsl#2334](https://github.com/querydsl/querydsl/issues/2334)). While it is mentioned as a known risk in the documentation, developers often have no way to detect it until their application hangs in production.

**Proposed Solution**

I have added a compile-time detection mechanism in `AbstractQuerydslProcessor` to identify potential deadlocks before they reach runtime.

Key Features:

- **Cycle Detection via DFS:** Implements a Depth-First Search traversal to find cycles in entity relationships.
- **Zero-Overhead for Production:** Uses a `globalVisited` set to ensure O(V+E) time complexity, preventing significant build-time slowdowns even in large projects.
- **Smart Filtering (Anti-False Positive):**
    - **Direct References Only:** Skips collection types (`LIST`, `SET`, `MAP`) because they are generated as `ListPath`, etc., which do not trigger the target Q-class loading during the `<clinit>` phase.
    - **Configuration Aware:** Only runs when `createDefaultVariable` is `true`, as disabling this option effectively prevents the deadlock.
- **Actionable Feedback:** Provides a clear warning message with three specific remediation strategies.

Example Warning Output:
<img width="1744" height="730" alt="image" src="https://github.com/user-attachments/assets/5552fcd1-ea5b-455a-ae94-1d1690646ea2" />
The screenshot above demonstrates how the warning is presented during the Gradle build process.

**Testing**

Added comprehensive test cases in `QuerydslAnnotationProcessorCompileTest` using `google/compile-testing`:

- `circularQClassReference_producesWarning`: Validates detection of direct bidirectional cycles.
- `indirectCircularReference_producesWarning`: Validates detection of multi-level cycles (A → B → C → A).
- `unidirectionalReference_noWarning`: Ensures no false warnings for safe, unidirectional paths.
- `collectionReference_noWarning`: **Crucial Test** - Confirms that `@OneToMany` (collections) do not trigger warnings, as they are safe from `<clinit>` deadlocks.

**Why This Location in `processAnnotations()`**

The detection runs just before `context.clean()`, after `typeFactory.extendTypes()`. At this point, `context.entityTypes` is fully populated with all entity properties, ensuring accurate cycle detection. Running it earlier would risk missing properties that haven't been resolved yet.