### PR TITLE
fix(apt): circular dependencies are not problematic

### DIFF
--- a/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
+++ b/querydsl-tooling/querydsl-apt/src/main/java/com/querydsl/apt/AbstractQuerydslProcessor.java
@@ -739,6 +739,8 @@ public abstract class AbstractQuerydslProcessor extends AbstractProcessor {
 
     for (Property property : current.getProperties()) {
       String neighborName = property.getType().getFullName();
+      if (neighborName.equals(currentName)) continue;
+
       EntityType neighbor = typeMap.get(neighborName);
       if (neighbor == null) continue;
 

--- a/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/QuerydslAnnotationProcessorCompileTest.java
+++ b/querydsl-tooling/querydsl-apt/src/test/java/com/querydsl/apt/QuerydslAnnotationProcessorCompileTest.java
@@ -249,6 +249,29 @@ class QuerydslAnnotationProcessorCompileTest {
   }
 
   @Test
+  void selfReference_noWarning() {
+    JavaFileObject orderSource =
+        JavaFileObjects.forSourceString(
+            "test.Order",
+            """
+                    package test;
+
+                    import com.querydsl.core.annotations.QueryEntity;
+
+                    @QueryEntity
+                    public class Order {
+                      public Order parent;
+                    }
+                    """);
+
+    Compilation compilation =
+        javac().withProcessors(new QuerydslAnnotationProcessor()).compile(orderSource);
+
+    CompilationSubject.assertThat(compilation).succeeded();
+    CompilationSubject.assertThat(compilation).hadWarningCount(0);
+  }
+
+  @Test
   void indirectCircularReference_producesWarning() {
     JavaFileObject aSource =
         JavaFileObjects.forSourceString(


### PR DESCRIPTION
Hello,

Renovate is trying to update QueryDSL from 7.1 to 7.2 [here](https://github.com/Athou/commafeed/pull/2156) but a warning is emitted. The build does not pass because warnings are treated as errors during the build of CommaFeed.

The warning is 
```
[WARNING] [QueryDSL] Circular Q-class references detected.
  This may cause class initialization deadlock in multi-threaded environments.
  
  Detected cycles:
    (1) FeedSubscription → FeedCategory → FeedCategory
  
  To avoid deadlock, consider:
    (1) Removing the bidirectional association on one side.
    (2) Pre-initializing Q-classes in a single thread before handling requests (e.g. via @PostConstruct).
    (3) Using 'new QClass("alias")' instead of static field access in your repositories.
```

I think this is caused by my self-referencing `FeedCategory` class where the `parent` field is referencing its own class.

```
@Entity
@Table(name = "FEEDCATEGORIES")
@SuppressWarnings("serial")
@Getter
@Setter
public class FeedCategory extends AbstractModel {

	@Column(length = 128, nullable = false)
	private String name;

	@ManyToOne(fetch = FetchType.LAZY)
	@JoinColumn(nullable = false)
	private User user;

	@ManyToOne(fetch = FetchType.LAZY)
	private FeedCategory parent;

	private boolean collapsed;

	private int position;

}
```

I think this is a false positive, hence the pull request, but let me know if it is the actual expected behavior and how to fix this warning if it is the case :slightly_smiling_face: 

Also pinging @o54711254 as the original author of https://github.com/OpenFeign/querydsl/pull/1739.
