### PR TITLE
Bump ibm image (old one is reported as ransomware by company firewall)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - "27017:27017"
 
   db2:
-    image: ibmcom/db2:11.5.0.0
+    image: ibmcom/db2:11.5.8.0
     platform: linux/amd64
     privileged: true
     ports:


### PR DESCRIPTION
Bump ibm image (old one is reported as ransomware by company firewall)