### PR TITLE
Render object arrays as Kotlin Array<T> in querydsl-kotlin-codegen (#1790)

### DIFF
--- a/querydsl-tooling/querydsl-kotlin-codegen/src/main/kotlin/com/querydsl/kotlin/codegen/Extensions.kt
+++ b/querydsl-tooling/querydsl-kotlin-codegen/src/main/kotlin/com/querydsl/kotlin/codegen/Extensions.kt
@@ -27,10 +27,26 @@ import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.joinToCode
 import kotlin.reflect.KClass
 
+private val PRIMITIVE_ARRAY_FULL_NAMES =
+    setOf("boolean[]", "byte[]", "char[]", "short[]", "int[]", "long[]", "float[]", "double[]")
+
+// Component type of an object array (e.g. String[]), or null for non-arrays and primitive
+// arrays. Primitive arrays (int[], byte[], ...) keep their dedicated Kotlin array class
+// (IntArray, ByteArray, ...) via asClassName() and must not be wrapped in Array<T>.
+private fun Type.objectArrayComponentType(): Type? =
+    componentType?.takeUnless { fullName in PRIMITIVE_ARRAY_FULL_NAMES }
+
 @JvmOverloads
-fun Type.asTypeName(out: Boolean = false): TypeName = asClassName().let { className ->
-    if (parameters.isNotEmpty())
-        className.parameterizedBy(*parameters.map { if (out) it.asOutTypeName() else it.asTypeName() }.toTypedArray()) else className
+fun Type.asTypeName(out: Boolean = false): TypeName {
+    // Object arrays (e.g. String[]) must be rendered as the Kotlin Array<T> type.
+    objectArrayComponentType()?.let { component ->
+        return Array::class.asClassName()
+            .parameterizedBy(if (out) component.asOutTypeName() else component.asTypeName())
+    }
+    return asClassName().let { className ->
+        if (parameters.isNotEmpty())
+            className.parameterizedBy(*parameters.map { if (out) it.asOutTypeName() else it.asTypeName() }.toTypedArray()) else className
+    }
 }
 
 fun Type.asClassName(): ClassName = when (this.fullName) {
@@ -67,7 +83,10 @@ private fun Type.enclosingTypeHierarchy(): List<String> {
 
 fun ClassName.asClassStatement() = CodeBlock.of("%T::class.java", this)
 
-fun Type.asClassNameStatement() = asClassName().asClassStatement()
+fun Type.asClassNameStatement(): CodeBlock =
+    // Object arrays need the Kotlin Array<T>::class.java form to resolve to the right runtime class.
+    objectArrayComponentType()?.let { CodeBlock.of("%T::class.java", asTypeName()) }
+        ?: asClassName().asClassStatement()
 
 fun TypeMappings.getPathClassName(type: Type, model: EntityType) = getPathType(type, model, true).asClassName()
 

--- a/querydsl-tooling/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/EntitySerializerTest.kt
+++ b/querydsl-tooling/querydsl-kotlin-codegen/src/test/kotlin/com/querydsl/kotlin/codegen/EntitySerializerTest.kt
@@ -118,6 +118,18 @@ class EntitySerializerTest {
     }
 
     @Test
+    fun object_array() {
+        val type = SimpleType(TypeCategory.ENTITY, "Entity", "", "Entity", false, false)
+        val entityType = EntityType(type)
+        entityType.addProperty(Property(entityType, "tags", ClassType(TypeCategory.ARRAY, Array<String>::class.java)))
+        typeMappings.register(entityType, queryTypeFactory.create(entityType))
+        serializer.serialize(entityType, SimpleSerializerConfig.DEFAULT, JavaWriter(writer))
+        Assertions.assertTrue(writer.toString().contains("val tags: ArrayPath<Array<String>, String>"))
+        Assertions.assertTrue(writer.toString().contains("createArray(\"tags\", Array<String>::class.java)"))
+        assertCompiles("QEntity", writer.toString())
+    }
+
+    @Test
     fun include() {
         val type = SimpleType(TypeCategory.ENTITY, "Entity", "", "Entity", false, false)
         val entityType = EntityType(type)


### PR DESCRIPTION
Fixes #1790

### Problem
`querydsl-kotlin-codegen` emitted object-array properties (e.g. `String[]`) using Java array syntax, producing code that does not compile:

```kotlin
val tags: ArrayPath<String[], String> = createArray("tags", String[]::class.java)
```

`String[]` and `String[]::class.java` are not valid Kotlin.

### Cause
In `Extensions.kt`, `Type.asClassName()` special-cases the eight primitive array types (`int[]` → `IntArray`, etc.), but object arrays fall through to the generic `ClassName(packageName, simpleName)` branch, where the array's `simpleName` (`String[]`) leaks into the generated source. `asClassNameStatement()` had the same gap.

### Fix
Map object arrays to the Kotlin `Array<T>` type and the `Array<T>::class.java` class literal, while leaving primitive arrays on their dedicated Kotlin array classes (`IntArray`, `ByteArray`, …). Object arrays are detected via `Type.getComponentType()`, excluding the primitive-array full names that `asClassName()` already handles. The same now generates:

```kotlin
val tags: ArrayPath<Array<String>, String> = createArray("tags", Array<String>::class.java)
```

### Tests
Added `EntitySerializerTest.object_array`, taken from the reproducer in #1790, which asserts the generated declaration/statement and (via the existing `assertCompiles` helper) that the output compiles.

```
mvn -Pno-databases -pl querydsl-tooling/querydsl-kotlin-codegen test
Tests run: 27, Failures: 0, Errors: 0, Skipped: 2 → BUILD SUCCESS
```

Verification done: (1) no in-flight PR/linked branch for the array bug; (2) no active claim on the issue (only the boilerplate template checkbox); (3) fix touches `.kt` files only; (4) confirmed the missing object-array case in `asClassName`/`asClassNameStatement` on current `master`; (5) reproduced with the issue's test, which failed before and passes after; full `querydsl-kotlin-codegen` test suite green with no regressions.
