### PR TITLE
Add flatten-maven-plugin to querydsl-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,8 @@
 
     <git-code-format-maven-plugin.version>6.0</git-code-format-maven-plugin.version>
 
+    <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
+
     <junit.version>6.1.0</junit.version>
     <ecj.version>3.46.0</ecj.version>
     <jdo.version>3.2.1</jdo.version>

--- a/querydsl-bom/pom.xml
+++ b/querydsl-bom/pom.xml
@@ -208,4 +208,39 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>${flatten-maven-plugin.version}</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <!-- Flatten and simplify our own POM for install/deploy -->
+            <id>flatten</id>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <updatePomFile>true</updatePomFile>
+              <flattenMode>bom</flattenMode>
+              <pomElements>
+                <dependencies>remove</dependencies>
+                <dependencyManagement>keep</dependencyManagement>
+                <distributionManagement>remove</distributionManagement>
+                <inceptionYear>remove</inceptionYear>
+                <issueManagement>remove</issueManagement>
+                <properties>remove</properties>
+                <repositories>remove</repositories>
+                <url>remove</url>
+              </pomElements>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/resources/bom-template.xml.vm
+++ b/src/main/resources/bom-template.xml.vm
@@ -47,4 +47,39 @@
 
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${flatten-maven-plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <!-- Flatten and simplify our own POM for install/deploy -->
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>bom</flattenMode>
+                            <pomElements>
+                                <dependencies>remove</dependencies>
+                                <dependencyManagement>keep</dependencyManagement>
+                                <distributionManagement>remove</distributionManagement>
+                                <inceptionYear>remove</inceptionYear>
+                                <issueManagement>remove</issueManagement>
+                                <properties>remove</properties>
+                                <repositories>remove</repositories>
+                                <url>remove</url>
+                            </pomElements>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This PR adds the `flatten-maven-plugin` to the `querydsl-bom` to not have it referene the project parent (`querydsl-root`) when published. This avoids unexpected dependency management overrides by the `dependencyManagement` block in the project parent when using the bom.

Fixes https://github.com/OpenFeign/querydsl/issues/1788