### PR TITLE
Pin netty-bom 4.1.135.Final in quarkus example to fix CVE alerts

### DIFF
--- a/querydsl-examples/querydsl-example-jpa-quarkus/pom.xml
+++ b/querydsl-examples/querydsl-example-jpa-quarkus/pom.xml
@@ -17,6 +17,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- imported before quarkus-bom to win on netty versions; quarkus 3.36.x
+           still manages netty 4.1.133, which has open CVEs fixed in 4.1.135 -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.1.135.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-bom</artifactId>


### PR DESCRIPTION
Quarkus 3.36.x manages netty 4.1.133.Final, which has open CVEs against netty-handler, netty-resolver-dns and netty-transport-native-epoll (alerts #72–77), fixed in 4.1.135.Final. This imports `netty-bom` 4.1.135.Final ahead of `quarkus-bom` so it wins on netty versions.

Verified: `dependency:tree` shows all netty artifacts at 4.1.135.Final and `FruitsEndpointTest` passes.

The remaining ~25 dependabot alerts are ghosts from a stale December 2024 dependency snapshot; restoring the dependency-submission workflow to supersede it is handled separately in the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)