### PR TITLE
Restore dependency-submission workflow, fixed for consistent runs

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,44 @@
+# The workflow name and job id form the snapshot job correlator ("build" via
+# the dependency-submission-toolkit). They must stay identical to the workflow
+# removed in 69d8be19c so submissions supersede the stale December 2024
+# snapshot that keeps old transitive versions alive in the dependency graph
+# (and keeps spawning Dependabot alerts for them).
+name: Dependabot Dependency Submission
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '23 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    # Dependabot and fork PRs run with a read-only GITHUB_TOKEN, so the
+    # snapshot submission would 403 and fail the check — the likely reason the
+    # original workflow was flaky. Skip those; pushes to master are what keep
+    # the dependency graph fresh.
+    if: github.event_name != 'pull_request' || (github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: maven
+
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v5.0.0
+        with:
+          maven-args: -Pexamples -Dtoolchain.skip=true

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -35,7 +35,9 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          # .mvn/jvm.config uses JDK 23+ flags (--sun-misc-unsafe-memory-access);
+          # keep in sync with the JDK the build actually targets
+          java-version: '25'
           cache: maven
 
       - name: Submit Dependency Snapshot


### PR DESCRIPTION
Restores the `Dependabot Dependency Submission` workflow removed in 69d8be19c ("Removing as can't get it working in a consistent manner"), with the inconsistency causes fixed.

## Why it was flaky in 2024

1. **No `permissions:` block** — submission needs `contents: write`; runs with a read-only default token 403'd on the snapshot POST.
2. **It triggered on every `pull_request`** — including Dependabot's PRs, whose runs always get a read-only `GITHUB_TOKEN` regardless of the permissions block. With this repo's volume of dependabot PRs, the check showed red constantly while pushes to master worked, i.e. "inconsistent".

## What changed vs the old version

- `permissions: contents: write` declared explicitly.
- PR runs are skipped for `dependabot[bot]` and fork PRs (read-only token → guaranteed 403); they show as *skipped*, not failed.
- Weekly `schedule` + `workflow_dispatch` as self-healing/manual triggers.
- `-Pexamples` so example modules (the quarkus one carries real compile-scope netty) are part of the graph.
- Action bumped to `maven-dependency-submission-action@v5.0.0`, checkout/setup-java to v4, with maven caching.

The **workflow name and job id are kept identical** to the 2024 version on purpose: the snapshot job correlator (`build`) must match so the first run on master supersedes the stale December 2024 snapshot that is the source of ~25 of the 31 open Dependabot alerts (see #1799 for the analysis; the one real vulnerability is patched there).

## Verification

- The exact maven invocation the action performs (`depgraph-maven-plugin:4.0.3:graph -DgraphFormat=json -Pexamples -Dtoolchain.skip=true`) was run locally against this branch: BUILD SUCCESS, 37 module graphs generated.
- This PR's own `Dependabot Dependency Submission / build` check exercises the full path end to end (same-repo human PR → write token → real submission against the PR ref).

After merging: the push to master runs the workflow and refreshes the graph; stale alerts should then auto-resolve. It can also be triggered immediately via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)