### PR TITLE
fix: ksp-codegen generates unqualified type reference for @EmbeddedId…

### DIFF
--- a/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelExtractor.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/main/kotlin/com/querydsl/ksp/codegen/QueryModelExtractor.kt
@@ -168,13 +168,22 @@ class QueryModelExtractor(
     }
 
     private fun toQueryModel(classDeclaration: KSClassDeclaration, type: QueryModelType, constructor: KSFunctionDeclaration?): QueryModel {
+        val simpleNames = generateSequence(classDeclaration) { it.parentDeclaration as? KSClassDeclaration }
+            .map { it.simpleName.asString() }
+            .toList()
+            .reversed()
+
         return QueryModel(
             // Build the ClassName from raw KSP names to avoid kotlinpoet-ksp's
             // toClassName(), which invalidates KSP2 lifetime tokens (see
             // superclassOrNull above for the same workaround).
+            // Inner classes need the full parent hierarchy passed as vararg simple names
+            // so KotlinPoet emits a qualified reference (e.g. Outer.Inner) instead of
+            // the bare Inner, which fails to resolve at compile time.
             originalClassName = ClassName(
                 classDeclaration.packageName.asString(),
-                classDeclaration.simpleName.asString()
+                simpleNames.first(),
+                *simpleNames.drop(1).toTypedArray()
             ),
             typeParameterCount = classDeclaration.typeParameters.size,
             className = queryClassName(classDeclaration, settings),

--- a/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/KspProcessorIntegrationTest.kt
+++ b/querydsl-tooling/querydsl-ksp-codegen/src/test/kotlin/KspProcessorIntegrationTest.kt
@@ -668,6 +668,43 @@ class KspProcessorIntegrationTest {
         return compilation.compile() to compilation.kspSourcesDir
     }
 
+    @Test
+    fun embeddableInnerClass_generatesQualifiedTypeReference() {
+        val source = SourceFile.kotlin(
+            "Invoice.kt",
+            """
+        package test
+
+        import jakarta.persistence.Embeddable
+        import jakarta.persistence.EmbeddedId
+        import jakarta.persistence.Entity
+        import java.io.Serializable
+
+        @Entity
+        class Invoice(
+            @EmbeddedId val id: InvoiceId
+        ) {
+            @Embeddable
+            data class InvoiceId(
+                val invoiceNo: String = "",
+                val seq: Int = 0
+            ) : Serializable
+        }
+        """.trimIndent()
+        )
+
+        val (result, generatedDir) = compile(source)
+
+        assertThat(result.exitCode)
+            .withFailMessage(result.messages)
+            .isEqualTo(KotlinCompilation.ExitCode.OK)
+
+        val qInvoiceId = generatedDir.findGenerated("QInvoice_InvoiceId.kt")
+        assertThat(qInvoiceId.readText())
+            .contains("Invoice.InvoiceId")
+            .doesNotContain("EmbeddablePath<InvoiceId>")
+    }
+
     private fun File.findGenerated(name: String): File {
         val match = walkTopDown().firstOrNull { it.isFile && it.name == name }
         assertThat(match)


### PR DESCRIPTION
Fixes #1805

## Problem
When `@EmbeddedId` is declared as an inner class of a JPA entity,
ksp-codegen generates an unqualified type reference that fails to compile.

## Root Cause
`QueryModelExtractor.toQueryModel()` builds `originalClassName` using only
`classDeclaration.simpleName`, which drops the enclosing class from the
generated type reference.

## Fix
Collect the full parent hierarchy via `generateSequence` and pass as vararg
to `ClassName`, matching the existing `queryClassName()` logic.