### PR TITLE
test: enable CUBRID integration test suites

### DIFF
--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/KeywordQuotingBase.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/KeywordQuotingBase.java
@@ -15,9 +15,11 @@
  */
 package com.querydsl.sql;
 
+import static com.querydsl.core.Target.CUBRID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Splitter;
+import com.querydsl.core.testutil.ExcludeIn;
 import com.querydsl.core.types.PathMetadata;
 import com.querydsl.core.types.PathMetadataFactory;
 import com.querydsl.core.types.dsl.BooleanPath;
@@ -86,6 +88,9 @@ public abstract class KeywordQuotingBase extends AbstractBaseTest {
   }
 
   @Test
+  // The bundled CUBRID 9.3.9 JDBC driver reports a malformed keyword list (e.g. "TATISTICS",
+  // "DATA_TYPE___"), so completeness against the curated keyword file cannot be asserted.
+  @ExcludeIn(CUBRID)
   public void validateKeywordsCompleteness() throws SQLException {
     var keywords =
         switch (target) {

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/SelectBase.java
@@ -782,7 +782,7 @@ public abstract class SelectBase extends AbstractBaseTest {
   }
 
   @Test
-  @ExcludeIn({SQLITE, TERADATA, DERBY, H2, TURSO}) // FIXME
+  @ExcludeIn({SQLITE, TERADATA, DERBY, H2, TURSO, CUBRID}) // FIXME
   public void date_trunc2() {
     DateTimeExpression<LocalDateTime> expr =
         DateTimeExpression.currentTimestamp(LocalDateTime.class);

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/suites/CUBRIDLiteralsSuiteTest.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/suites/CUBRIDLiteralsSuiteTest.java
@@ -14,11 +14,9 @@ import com.querydsl.sql.TypesBase;
 import com.querydsl.sql.UnionBase;
 import com.querydsl.sql.UpdateBase;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
-@Disabled
 @Tag("com.querydsl.core.testutil.CUBRID")
 public class CUBRIDLiteralsSuiteTest extends AbstractSuite {
 

--- a/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/suites/CUBRIDSuiteTest.java
+++ b/querydsl-libraries/querydsl-sql/src/test/java/com/querydsl/sql/suites/CUBRIDSuiteTest.java
@@ -14,11 +14,9 @@ import com.querydsl.sql.TypesBase;
 import com.querydsl.sql.UnionBase;
 import com.querydsl.sql.UpdateBase;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
-@Disabled
 @Tag("com.querydsl.core.testutil.CUBRID")
 public class CUBRIDSuiteTest extends AbstractSuite {
 


### PR DESCRIPTION
## Summary

Enables the CUBRID integration test suites, which were marked `@Disabled` (bare, no reason) during the JUnit 5 migration (#1776) and therefore ran **0 tests**.

With the suites enabled, **608 CUBRID tests pass** against `cubrid/cubrid:11.3` (verified locally and in GHA). Two CUBRID-specific issues are handled the same way every other backend handles its gaps:

- **`SelectBase.date_trunc2`** → `UnsupportedOperationException` (the CUBRID dialect doesn't implement that `date_trunc` form, same as SQLite/Derby/H2/Turso). Added `CUBRID` to its existing `@ExcludeIn`.
- **`KeywordQuotingBase.validateKeywordsCompleteness`** → excluded for CUBRID. The bundled CUBRID 9.3.9 JDBC driver reports a malformed keyword list (literally `TATISTICS`, plus `DATA_TYPE___`/`SCOPE___`), so completeness against the curated keyword file can't be asserted without committing a driver typo.

Result: `Tests run: 608, Failures: 0, Errors: 0, Skipped: 131`.

## Notes
- These are test-only changes; no production code is touched.
- On CircleCI the CUBRID job builds the full reactor before testing, so the container is ready by test time. The companion GitHub Actions migration (#1814) adds a `demodb`-readiness wait for the faster cached build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPLya3e3DqdYmfdaoH3L6o
