### PR TITLE
Extend multi-row INSERT (addRow) to execute() and loop-friendly call shapes (#1825)

### DIFF
--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JpaInsertNativeHelper.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JpaInsertNativeHelper.java
@@ -39,6 +39,29 @@ public final class JpaInsertNativeHelper {
   private JpaInsertNativeHelper() {}
 
   /**
+   * Ensure the optional {@code querydsl-sql} module is on the classpath before taking a native SQL
+   * insert path. {@code querydsl-jpa} declares {@code querydsl-sql} as an <em>optional</em>
+   * dependency (it is only needed for the {@link JpaNativeInsertSerializer}-based paths such as
+   * {@code executeWithKey()}, {@code executeWithKeys()} and multi-row {@code execute()}), so a
+   * JPA-only consumer will not have it transitively. Without this guard the caller would hit an
+   * opaque {@link NoClassDefFoundError}; instead we fail fast with an actionable message.
+   *
+   * @throws IllegalStateException if {@code querydsl-sql} is not available
+   */
+  public static void requireSqlModule() {
+    try {
+      Class.forName("com.querydsl.sql.SQLSerializer");
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException(
+          "This operation requires the optional querydsl-sql module, which is not on the"
+              + " classpath. Add the 'io.github.openfeign.querydsl:querydsl-sql' dependency"
+              + " (matching your querydsl-jpa version) to use executeWithKey(), executeWithKeys()"
+              + " or multi-row execute() via addRow().",
+          e);
+    }
+  }
+
+  /**
    * Resolve the effective column paths from either the {@code set()}-style inserts map or the
    * {@code columns()}-style list. The {@code set()}-style takes precedence when present.
    */

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateInsertClause.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateInsertClause.java
@@ -61,6 +61,14 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
 
   private final List<List<Expression<?>>> rows = new ArrayList<>();
 
+  /**
+   * Column paths captured at the first {@link #addRow()} call. After {@code addRow()} clears the
+   * per-row {@code inserts}/{@code values} buffer, this lets executors recover the column list when
+   * the trailing iteration was also flushed (e.g. {@code for (...) { insert.set(...).addRow(); }}).
+   * Null until the first {@code addRow()}.
+   */
+  @Nullable private List<Path<?>> rowColumnPaths;
+
   private SubQueryExpression<?> subQuery;
 
   private final SessionHolder session;
@@ -152,6 +160,9 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
     }
 
     var effectiveColumns = JpaInsertNativeHelper.effectiveColumns(inserts, columns);
+    if (effectiveColumns.isEmpty() && rowColumnPaths != null) {
+      effectiveColumns = new ArrayList<>(rowColumnPaths);
+    }
     if (effectiveColumns.isEmpty()) {
       throw new IllegalStateException("No columns specified for insert");
     }
@@ -290,6 +301,9 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
     if (values.isEmpty() && inserts.isEmpty()) {
       throw new IllegalStateException("No values to add as row");
     }
+    if (rowColumnPaths == null) {
+      rowColumnPaths = JpaInsertNativeHelper.effectiveColumns(inserts, columns);
+    }
     rows.add(JpaInsertNativeHelper.effectiveValues(inserts, values));
     values.clear();
     inserts.clear();
@@ -329,6 +343,9 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
     }
 
     var effectiveColumns = JpaInsertNativeHelper.effectiveColumns(inserts, columns);
+    if (effectiveColumns.isEmpty() && rowColumnPaths != null) {
+      effectiveColumns = new ArrayList<>(rowColumnPaths);
+    }
     if (effectiveColumns.isEmpty()) {
       throw new IllegalStateException("No columns specified for insert");
     }

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateInsertClause.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateInsertClause.java
@@ -90,6 +90,12 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
 
   @Override
   public long execute() {
+    // Multi-row insert accumulated via addRow(): emit a single native
+    // INSERT INTO t (...) VALUES (..),(..),... statement in one round-trip.
+    if (!rows.isEmpty()) {
+      return executeMultiRow();
+    }
+
     if (subQuery != null || !hasTemplateValue()) {
       var serializer = new JPQLSerializer(templates, null);
       serializer.serializeForInsert(
@@ -116,6 +122,7 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
+    JpaInsertNativeHelper.requireSqlModule();
     var serializer = new JpaNativeInsertSerializer(new Configuration(SQLTemplates.DEFAULT));
     serializer.serializeInsert(entityClass, effectiveColumns, effectiveValues);
 
@@ -130,6 +137,47 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
             return JpaInsertNativeHelper.executeUpdate(connection, sql, params);
           } catch (SQLException e) {
             throw new QueryException("Failed to execute insert", e);
+          }
+        });
+  }
+
+  /**
+   * Execute a multi-row INSERT (accumulated via {@link #addRow()}) as a single native {@code INSERT
+   * INTO t (...) VALUES (..),(..),...} statement, returning the number of affected rows. This path
+   * does not return generated keys; use {@link #executeWithKeys(Class)} when keys are needed.
+   */
+  private long executeMultiRow() {
+    if (subQuery != null) {
+      throw new IllegalStateException("addRow is not supported with INSERT ... SELECT subqueries");
+    }
+
+    var effectiveColumns = JpaInsertNativeHelper.effectiveColumns(inserts, columns);
+    if (effectiveColumns.isEmpty()) {
+      throw new IllegalStateException("No columns specified for insert");
+    }
+
+    var allRows = new ArrayList<>(rows);
+    if (!values.isEmpty() || !inserts.isEmpty()) {
+      allRows.add(JpaInsertNativeHelper.effectiveValues(inserts, values));
+    }
+
+    var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
+
+    JpaInsertNativeHelper.requireSqlModule();
+    var serializer = new JpaNativeInsertSerializer(new Configuration(SQLTemplates.DEFAULT));
+    serializer.serializeInsertRows(entityClass, effectiveColumns, allRows);
+
+    var sql = serializer.toString();
+    var params =
+        JpaInsertNativeHelper.resolveConstants(
+            serializer.getConstants(), queryMixin.getMetadata().getParams());
+
+    return session.doReturningWork(
+        connection -> {
+          try {
+            return JpaInsertNativeHelper.executeUpdate(connection, sql, params);
+          } catch (SQLException e) {
+            throw new QueryException("Failed to execute multi-row insert", e);
           }
         });
   }
@@ -202,6 +250,7 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
+    JpaInsertNativeHelper.requireSqlModule();
     var serializer = new JpaNativeInsertSerializer(new Configuration(SQLTemplates.DEFAULT));
     serializer.serializeInsert(entityClass, effectiveColumns, effectiveValues);
 
@@ -222,8 +271,13 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
 
   /**
    * Append the current {@code values()} (or {@code set()}) state as a row and clear it for the next
-   * row. Use together with {@link #executeWithKeys(Class)} to issue a multi-row {@code INSERT INTO
-   * t (...) VALUES (..),(..),...} as a single SQL statement.
+   * row. Accumulated rows are emitted as a single multi-row {@code INSERT INTO t (...) VALUES
+   * (..),(..),...} statement by either {@link #execute()} (no keys) or {@link
+   * #executeWithKeys(Class)} (returning generated keys).
+   *
+   * <p><strong>Note:</strong> this is <em>not</em> JDBC batching ({@code
+   * PreparedStatement.addBatch()}/{@code executeBatch()}, i.e. many statements grouped into one
+   * round-trip). It builds a single SQL statement with multiple {@code VALUES} tuples.
    *
    * @return this clause for chaining
    * @throws IllegalStateException if no values have been specified for the current row, or if
@@ -289,6 +343,7 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
+    JpaInsertNativeHelper.requireSqlModule();
     var serializer = new JpaNativeInsertSerializer(new Configuration(SQLTemplates.DEFAULT));
     serializer.serializeInsertRows(entityClass, effectiveColumns, allRows);
 

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAInsertClause.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAInsertClause.java
@@ -76,6 +76,12 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
 
   @Override
   public long execute() {
+    // Multi-row insert accumulated via addRow(): emit a single native
+    // INSERT INTO t (...) VALUES (..),(..),... statement in one round-trip.
+    if (!rows.isEmpty()) {
+      return executeMultiRow();
+    }
+
     if (subQuery != null || !hasTemplateValue()) {
       var serializer = new JPQLSerializer(templates, entityManager);
       serializer.serializeForInsert(
@@ -101,6 +107,7 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
+    JpaInsertNativeHelper.requireSqlModule();
     var serializer = new JpaNativeInsertSerializer(new Configuration(SQLTemplates.DEFAULT));
     serializer.serializeInsert(entityClass, effectiveColumns, effectiveValues);
 
@@ -111,6 +118,44 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
 
     // Provider-neutral native execute: use the JPA standard EntityManager.createNativeQuery
     // instead of unwrapping a Hibernate Session, so this path also works under EclipseLink/OpenJPA.
+    var nativeQuery = entityManager.createNativeQuery(sql);
+    for (int i = 0; i < params.length; i++) {
+      nativeQuery.setParameter(i + 1, params[i]);
+    }
+    return nativeQuery.executeUpdate();
+  }
+
+  /**
+   * Execute a multi-row INSERT (accumulated via {@link #addRow()}) as a single native {@code INSERT
+   * INTO t (...) VALUES (..),(..),...} statement, returning the number of affected rows. This path
+   * does not return generated keys; use {@link #executeWithKeys(Class)} when keys are needed.
+   */
+  private long executeMultiRow() {
+    if (subQuery != null) {
+      throw new IllegalStateException("addRow is not supported with INSERT ... SELECT subqueries");
+    }
+
+    var effectiveColumns = JpaInsertNativeHelper.effectiveColumns(inserts, columns);
+    if (effectiveColumns.isEmpty()) {
+      throw new IllegalStateException("No columns specified for insert");
+    }
+
+    var allRows = new ArrayList<>(rows);
+    if (!values.isEmpty() || !inserts.isEmpty()) {
+      allRows.add(JpaInsertNativeHelper.effectiveValues(inserts, values));
+    }
+
+    var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
+
+    JpaInsertNativeHelper.requireSqlModule();
+    var serializer = new JpaNativeInsertSerializer(new Configuration(SQLTemplates.DEFAULT));
+    serializer.serializeInsertRows(entityClass, effectiveColumns, allRows);
+
+    var sql = serializer.toString();
+    var params =
+        JpaInsertNativeHelper.resolveConstants(
+            serializer.getConstants(), queryMixin.getMetadata().getParams());
+
     var nativeQuery = entityManager.createNativeQuery(sql);
     for (int i = 0; i < params.length; i++) {
       nativeQuery.setParameter(i + 1, params[i]);
@@ -187,6 +232,7 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
+    JpaInsertNativeHelper.requireSqlModule();
     var serializer = new JpaNativeInsertSerializer(new Configuration(SQLTemplates.DEFAULT));
     serializer.serializeInsert(entityClass, effectiveColumns, effectiveValues);
 
@@ -208,8 +254,13 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
 
   /**
    * Append the current {@code values()} (or {@code set()}) state as a row and clear it for the next
-   * row. Use together with {@link #executeWithKeys(Class)} to issue a multi-row {@code INSERT INTO
-   * t (...) VALUES (..),(..),...} as a single SQL statement.
+   * row. Accumulated rows are emitted as a single multi-row {@code INSERT INTO t (...) VALUES
+   * (..),(..),...} statement by either {@link #execute()} (no keys) or {@link
+   * #executeWithKeys(Class)} (returning generated keys).
+   *
+   * <p><strong>Note:</strong> this is <em>not</em> JDBC batching ({@code
+   * PreparedStatement.addBatch()}/{@code executeBatch()}, i.e. many statements grouped into one
+   * round-trip). It builds a single SQL statement with multiple {@code VALUES} tuples.
    *
    * @return this clause for chaining
    * @throws IllegalStateException if no values have been specified for the current row, or if
@@ -275,6 +326,7 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
+    JpaInsertNativeHelper.requireSqlModule();
     var serializer = new JpaNativeInsertSerializer(new Configuration(SQLTemplates.DEFAULT));
     serializer.serializeInsertRows(entityClass, effectiveColumns, allRows);
 

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAInsertClause.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAInsertClause.java
@@ -56,6 +56,14 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
 
   private final List<List<Expression<?>>> rows = new ArrayList<>();
 
+  /**
+   * Column paths captured at the first {@link #addRow()} call. After {@code addRow()} clears the
+   * per-row {@code inserts}/{@code values} buffer, this lets executors recover the column list when
+   * the trailing iteration was also flushed (e.g. {@code for (...) { insert.set(...).addRow(); }}).
+   * Null until the first {@code addRow()}.
+   */
+  @Nullable private List<Path<?>> rowColumnPaths;
+
   private final EntityManager entityManager;
 
   private final JPQLTemplates templates;
@@ -136,6 +144,9 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
     }
 
     var effectiveColumns = JpaInsertNativeHelper.effectiveColumns(inserts, columns);
+    if (effectiveColumns.isEmpty() && rowColumnPaths != null) {
+      effectiveColumns = new ArrayList<>(rowColumnPaths);
+    }
     if (effectiveColumns.isEmpty()) {
       throw new IllegalStateException("No columns specified for insert");
     }
@@ -273,6 +284,9 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
     if (values.isEmpty() && inserts.isEmpty()) {
       throw new IllegalStateException("No values to add as row");
     }
+    if (rowColumnPaths == null) {
+      rowColumnPaths = JpaInsertNativeHelper.effectiveColumns(inserts, columns);
+    }
     rows.add(JpaInsertNativeHelper.effectiveValues(inserts, values));
     values.clear();
     inserts.clear();
@@ -312,6 +326,9 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
     }
 
     var effectiveColumns = JpaInsertNativeHelper.effectiveColumns(inserts, columns);
+    if (effectiveColumns.isEmpty() && rowColumnPaths != null) {
+      effectiveColumns = new ArrayList<>(rowColumnPaths);
+    }
     if (effectiveColumns.isEmpty()) {
       throw new IllegalStateException("No columns specified for insert");
     }

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateExecuteWithKeyTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateExecuteWithKeyTest.java
@@ -266,6 +266,36 @@ public class HibernateExecuteWithKeyTest {
   }
 
   @Test
+  public void execute_multi_row_set_style_with_trailing_addRow() {
+    // The loop-friendly shape for set()-style: every iteration calls set()...addRow().
+    // After the loop, inserts/columns are both empty (set() goes into inserts which addRow()
+    // clears), but addRow() captures the column paths on its first call so executors can
+    // recover the column list. No "first row" flag, no buffer-retention trick.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var insert = insert(entity);
+    for (var name : new String[] {"Set1", "Set2", "Set3"}) {
+      insert.set(entity.name, name).addRow();
+    }
+    long rows = insert.execute();
+
+    assertThat(rows).isEqualTo(3L);
+  }
+
+  @Test
+  public void executeWithKeys_multi_row_set_style_with_trailing_addRow() {
+    // Same loop-friendly shape but routed through executeWithKeys to return generated keys.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var insert = insert(entity);
+    for (var name : new String[] {"KSet1", "KSet2"}) {
+      insert.set(entity.name, name).addRow();
+    }
+    var keys = insert.executeWithKeys(entity.id);
+
+    assertThat(keys).hasSize(2);
+    assertThat(keys.get(0)).isLessThan(keys.get(1));
+  }
+
+  @Test
   public void execute_without_template_uses_jpql_path() {
     // Regression for #1757: plain value INSERTs must keep using the JPQL path so
     // JPA semantics (cascade, callbacks where applicable) are preserved.

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateExecuteWithKeyTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateExecuteWithKeyTest.java
@@ -227,6 +227,45 @@ public class HibernateExecuteWithKeyTest {
   }
 
   @Test
+  public void execute_multi_row_without_keys_inserts_all_rows() {
+    // #1692 follow-up: addRow() must also work without returning keys — a plain
+    // execute() should emit a single multi-row INSERT and report all affected rows.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    long rows =
+        insert(entity)
+            .columns(entity.name)
+            .values("MR-A")
+            .addRow()
+            .values("MR-B")
+            .addRow()
+            .values("MR-C")
+            .execute();
+
+    assertThat(rows).isEqualTo(3L);
+
+    var count =
+        session
+            .createNativeQuery(
+                "select count(*) from generated_key_entity where name_ like 'MR-%'", Long.class)
+            .getSingleResult();
+    assertThat(count).isEqualTo(3L);
+  }
+
+  @Test
+  public void execute_multi_row_in_a_loop_with_trailing_addRow() {
+    // The loop-friendly shape: every iteration appends a row, no "is this the first row?"
+    // bookkeeping, and a trailing addRow() is fine.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var clause = insert(entity).columns(entity.name);
+    for (var name : new String[] {"Loop1", "Loop2", "Loop3", "Loop4"}) {
+      clause.values(name).addRow();
+    }
+    long rows = clause.execute();
+
+    assertThat(rows).isEqualTo(4L);
+  }
+
+  @Test
   public void execute_without_template_uses_jpql_path() {
     // Regression for #1757: plain value INSERTs must keep using the JPQL path so
     // JPA semantics (cascade, callbacks where applicable) are preserved.

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAExecuteWithKeyTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAExecuteWithKeyTest.java
@@ -285,6 +285,36 @@ public class JPAExecuteWithKeyTest {
   }
 
   @Test
+  public void execute_multi_row_set_style_with_trailing_addRow() {
+    // The loop-friendly shape for set()-style: every iteration calls set()...addRow().
+    // After the loop, inserts/columns are both empty (set() goes into inserts which addRow()
+    // clears), but addRow() captures the column paths on its first call so executors can
+    // recover the column list. No "first row" flag, no buffer-retention trick.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var insert = insert(entity);
+    for (var name : new String[] {"Set1", "Set2", "Set3"}) {
+      insert.set(entity.name, name).addRow();
+    }
+    long rows = insert.execute();
+
+    assertThat(rows).isEqualTo(3L);
+  }
+
+  @Test
+  public void executeWithKeys_multi_row_set_style_with_trailing_addRow() {
+    // Same loop-friendly shape but routed through executeWithKeys to return generated keys.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var insert = insert(entity);
+    for (var name : new String[] {"KSet1", "KSet2"}) {
+      insert.set(entity.name, name).addRow();
+    }
+    var keys = insert.executeWithKeys(entity.id);
+
+    assertThat(keys).hasSize(2);
+    assertThat(keys.get(0)).isLessThan(keys.get(1));
+  }
+
+  @Test
   public void execute_without_template_uses_jpql_path() {
     // Regression for #1757: plain value INSERTs must keep using the JPQL path so
     // JPA semantics (cascade, callbacks where applicable) are preserved.

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAExecuteWithKeyTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAExecuteWithKeyTest.java
@@ -245,6 +245,46 @@ public class JPAExecuteWithKeyTest {
   }
 
   @Test
+  public void execute_multi_row_without_keys_inserts_all_rows() {
+    // #1692 follow-up: addRow() must also work without returning keys — a plain
+    // execute() should emit a single multi-row INSERT and report all affected rows.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    long rows =
+        insert(entity)
+            .columns(entity.name)
+            .values("MR-A")
+            .addRow()
+            .values("MR-B")
+            .addRow()
+            .values("MR-C")
+            .execute();
+
+    assertThat(rows).isEqualTo(3L);
+
+    var count =
+        (Number)
+            entityManager
+                .createNativeQuery(
+                    "select count(*) from generated_key_entity where name_ like 'MR-%'")
+                .getSingleResult();
+    assertThat(count.longValue()).isEqualTo(3L);
+  }
+
+  @Test
+  public void execute_multi_row_in_a_loop_with_trailing_addRow() {
+    // The loop-friendly shape: every iteration appends a row, no "is this the first row?"
+    // bookkeeping, and a trailing addRow() is fine.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var clause = insert(entity).columns(entity.name);
+    for (var name : new String[] {"Loop1", "Loop2", "Loop3", "Loop4"}) {
+      clause.values(name).addRow();
+    }
+    long rows = clause.execute();
+
+    assertThat(rows).isEqualTo(4L);
+  }
+
+  @Test
   public void execute_without_template_uses_jpql_path() {
     // Regression for #1757: plain value INSERTs must keep using the JPQL path so
     // JPA semantics (cascade, callbacks where applicable) are preserved.


### PR DESCRIPTION
## Summary

Closes #1825. Two related improvements to multi-row INSERT support via `addRow()` on `JPAInsertClause` / `HibernateInsertClause`:

1. **Multi-row execution without returning keys** — a plain `execute()` now emits a single native `INSERT INTO t (...) VALUES (..),(..),...` when rows were accumulated via `addRow()`, returning the affected row count. Previously this only worked through `executeWithKeys(...)`, forcing callers to use a key-returning method even when keys were not needed.
2. **Loop-friendly multi-row call shape** — `addRow()` now captures effective column paths on its first call. `execute()` (multi-row path) and `executeWithKeys(...)` fall back to those captured paths when the current-state `inserts`/`columns` are empty. This makes the natural for-loop with `set(...).addRow()` at the end of every iteration work, without a "first row" flag and without keeping the last row in the buffer.

## Call site shapes that now work

```java
// set()-style, trailing addRow(), no keys needed
var insert = queryFactory.insert(entity);
for (var r : rows) {
  insert
      .set(entity.a, r.a())
      .set(entity.b, r.b())
      .addRow();
}
long count = insert.execute();

// columns()/values()-style, trailing addRow(), keys returned
var keys = queryFactory.insert(entity)
    .columns(entity.a, entity.b)
    .values(1, "x").addRow()
    .values(2, "y").addRow()
    .executeWithKeys(entity.id);
```

## Behavioral changes

- `JPAInsertClause.execute()` / `HibernateInsertClause.execute()`:
  - If `rows` (accumulated via `addRow()`) is non-empty and no `subQuery` is set, emits a single native multi-row `INSERT INTO t (...) VALUES (..),(..),...` and returns the affected row count.
  - All other cases (single-row plain INSERTs, `INSERT ... SELECT`, template-value INSERTs already routed through native) keep their existing path.
- `addRow()`:
  - Captures effective column paths once, on its first call. Executors use those captured paths as fallback when `inserts`/`columns` are both empty (i.e. the trailing iteration was also closed with `addRow()`).
- `JpaInsertNativeHelper.requireSqlModule()` (added): native insert paths depend on the optional `querydsl-sql` module; guards them with an actionable `IllegalStateException` instead of an opaque `NoClassDefFoundError` when `querydsl-sql` is absent from the classpath.
- `addRow()` Javadoc clarified: builds a single multi-row `VALUES` statement, not JDBC batching.

## Out of scope / clarifications

- `addRow()` builds a single SQL statement with multiple `VALUES` tuples. It is **not** JDBC batching (`PreparedStatement.addBatch()` / `executeBatch()`).
- Single-row inserts without `addRow()` are unchanged.
- `INSERT ... SELECT` (`select(SubQueryExpression)`) is unchanged and still rejects `addRow()`.

## Test plan

- [x] New unit/integration tests in `JPAExecuteWithKeyTest` and `HibernateExecuteWithKeyTest` covering both new shapes:
  - `execute_multi_row_set_style_with_trailing_addRow` — `set()` + trailing `addRow()` + `execute()` (no keys)
  - `executeWithKeys_multi_row_set_style_with_trailing_addRow` — same shape + key return
  - `execute_multi_row_without_keys_inserts_all_rows` — `columns()`/`values()` + addRow + `execute()`
  - `execute_multi_row_in_a_loop_with_trailing_addRow` — loop-friendly form with `columns()`/`values()`
- [x] `./mvnw -pl querydsl-libraries/querydsl-jpa -Pno-databases test` — 414 tests pass, 0 failures.