### PR TITLE
feat: add null-safe nullable-argument extensions for querydsl-kotlin

### DIFF
--- a/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/ComparableExpressionExtensions.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/ComparableExpressionExtensions.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.kotlin
+
+import com.querydsl.core.types.Expression
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.ComparableExpression
+
+/**
+ * Null-safe greater-than against a value, skipping when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this > value, or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.gt(value: T?): BooleanExpression? =
+    if (this == null || value == null) null else this.gt(value)
+
+/**
+ * Null-safe greater-than against another expression, skipping when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this > expr, or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.gt(expr: Expression<T>?): BooleanExpression? =
+    if (this == null || expr == null) null else this.gt(expr)
+
+/**
+ * Null-safe greater-than-or-equal against a value, skipping when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this >= value, or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.goe(value: T?): BooleanExpression? =
+    if (this == null || value == null) null else this.goe(value)
+
+/**
+ * Null-safe greater-than-or-equal against another expression, skipping when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this >= expr, or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.goe(expr: Expression<T>?): BooleanExpression? =
+    if (this == null || expr == null) null else this.goe(expr)
+
+/**
+ * Null-safe less-than against a value, skipping when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this < value, or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.lt(value: T?): BooleanExpression? =
+    if (this == null || value == null) null else this.lt(value)
+
+/**
+ * Null-safe less-than against another expression, skipping when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this < expr, or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.lt(expr: Expression<T>?): BooleanExpression? =
+    if (this == null || expr == null) null else this.lt(expr)
+
+/**
+ * Null-safe less-than-or-equal against a value, skipping when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this <= value, or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.loe(value: T?): BooleanExpression? =
+    if (this == null || value == null) null else this.loe(value)
+
+/**
+ * Null-safe less-than-or-equal against another expression, skipping when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this <= expr, or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.loe(expr: Expression<T>?): BooleanExpression? =
+    if (this == null || expr == null) null else this.loe(expr)
+
+/**
+ * Null-safe BETWEEN with partial-range support, judging each bound independently.
+ *
+ * Both bounds present yields BETWEEN, lower-only yields `>=`, upper-only yields `<=`,
+ * and neither is skipped.
+ *
+ * @param range a `from to to` pair where either bound may be null
+ * @return this BETWEEN from AND to (or a one-sided `>=` / `<=`), or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.between(range: Pair<T?, T?>): BooleanExpression? {
+    if (this == null) return null
+    val (from, to) = range
+    return when {
+        from != null && to != null -> this.between(from, to)
+        from != null -> this.goe(from)
+        to != null -> this.loe(to)
+        else -> null
+    }
+}
+
+/**
+ * Null-safe BETWEEN over a Kotlin [ClosedRange], where both bounds are always present.
+ *
+ * @param range the closed range (`from..to`)
+ * @return this BETWEEN from AND to, or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.between(range: ClosedRange<T>): BooleanExpression? =
+    this?.between(range.start, range.endInclusive)
+
+/**
+ * Null-safe NOT BETWEEN, mirroring [between] with partial-range support.
+ *
+ * Both bounds present yields NOT BETWEEN, lower-only yields `<`, upper-only yields `>`,
+ * and neither is skipped.
+ *
+ * @param range a `from to to` pair where either bound may be null
+ * @return this NOT BETWEEN from AND to (or a one-sided `<` / `>`), or null
+ */
+infix fun <T : Comparable<T>> ComparableExpression<T>?.notBetween(range: Pair<T?, T?>): BooleanExpression? {
+    if (this == null) return null
+    val (from, to) = range
+    return when {
+        from != null && to != null -> this.notBetween(from, to)
+        from != null -> this.lt(from)
+        to != null -> this.gt(to)
+        else -> null
+    }
+}

--- a/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/ExpressionExtensions.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/ExpressionExtensions.kt
@@ -20,52 +20,66 @@ import com.querydsl.core.types.dsl.*
 import com.querydsl.core.types.dsl.Expressions.constant
 
 /**
- * Get a negation of this boolean expression
+ * Null-safe negation that skips when this is null.
  *
- * @return !this
+ * @return NOT this, or null
  */
-operator fun Expression<Boolean>.not() : BooleanExpression {
-    return Expressions.booleanOperation(Ops.NOT, this)
+operator fun Expression<Boolean>?.not() : BooleanExpression? {
+    return if (this == null) null else Expressions.booleanOperation(Ops.NOT, this)
 }
 
 /**
- * Get an intersection of this and the given expression
+ * Null-safe intersection. A null side is skipped: both present -> AND, one present -> that side,
+ * both null -> null (dropped by where()).
  *
- * @param predicate right hand side of the union
- * @return this and right
+ * @param predicate right-hand side, or null to skip
+ * @return this AND predicate (or the present side), or null
  */
-infix fun Expression<Boolean>.and(predicate: Expression<Boolean>) : BooleanExpression {
-    return Expressions.booleanOperation(Ops.AND, this, predicate);
+infix fun Expression<Boolean>?.and(predicate: Expression<Boolean>?) : BooleanExpression? {
+    return when {
+        this != null && predicate != null -> Expressions.booleanOperation(Ops.AND, this, predicate)
+        this != null -> Expressions.asBoolean(this)
+        predicate != null -> Expressions.asBoolean(predicate)
+        else -> null
+    }
 }
 
 /**
- * Get a union of this and the given expression
+ * Null-safe union. A null side is skipped: both present -> OR, one present -> that side,
+ * both null -> null.
  *
- * @param predicate right hand side of the union
- * @return this || right
+ * @param predicate right-hand side, or null to skip
+ * @return this OR predicate (or the present side), or null
  */
-infix fun Expression<Boolean>.or(predicate: Expression<Boolean>) : BooleanExpression {
-    return Expressions.booleanOperation(Ops.OR, this, predicate);
+infix fun Expression<Boolean>?.or(predicate: Expression<Boolean>?) : BooleanExpression? {
+    return when {
+        this != null && predicate != null -> Expressions.booleanOperation(Ops.OR, this, predicate)
+        this != null -> Expressions.asBoolean(this)
+        predicate != null -> Expressions.asBoolean(predicate)
+        else -> null
+    }
 }
 
 /**
- * Get a union of this and the given expression
+ * Null-safe XOR that skips when either side is null (XOR has no meaningful one-sided form).
  *
- * @param predicate right hand side of the union
- * @return this || right
+ * @param predicate right-hand side, or null to skip
+ * @return this XOR predicate, or null
  */
-infix fun Expression<Boolean>.xor(predicate: Expression<Boolean>) : BooleanExpression {
-    return Expressions.booleanOperation(Ops.XOR, this, predicate);
+infix fun Expression<Boolean>?.xor(predicate: Expression<Boolean>?) : BooleanExpression? {
+    return if (this == null || predicate == null) null
+    else Expressions.booleanOperation(Ops.XOR, this, predicate)
 }
 
 /**
- * Get a union of this and the given expression
+ * Null-safe XNOR that skips when either side is null.
  *
- * @param predicate right hand side of the union
- * @return this || right
+ * @param predicate right-hand side, or null to skip
+ * @return this XNOR predicate, or null
  */
-infix fun Expression<Boolean>.xnor(predicate: Expression<Boolean>) : BooleanExpression {
-    return Expressions.booleanOperation(Ops.XNOR, this, predicate);
+infix fun Expression<Boolean>?.xnor(predicate: Expression<Boolean>?) : BooleanExpression? {
+    return if (this == null || predicate == null) null
+    else Expressions.booleanOperation(Ops.XNOR, this, predicate)
 }
 
 /**

--- a/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/NumberExpressionExtensions.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/NumberExpressionExtensions.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.kotlin
+
+import com.querydsl.core.types.Expression
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.NumberExpression
+
+// NumberExpression does not extend ComparableExpression, so these comparison helpers are declared
+// separately from the ComparableExpression extensions.
+
+/**
+ * Null-safe greater-than against a value, skipping when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this > value, or null
+ */
+infix fun <T> NumberExpression<T>?.gt(value: T?): BooleanExpression? where T : Number, T : Comparable<T> =
+    if (this == null || value == null) null else this.gt(value)
+
+/**
+ * Null-safe greater-than against another expression, skipping when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this > expr, or null
+ */
+infix fun <T> NumberExpression<T>?.gt(expr: Expression<T>?): BooleanExpression? where T : Number, T : Comparable<T> =
+    if (this == null || expr == null) null else this.gt(expr)
+
+/**
+ * Null-safe greater-than-or-equal against a value, skipping when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this >= value, or null
+ */
+infix fun <T> NumberExpression<T>?.goe(value: T?): BooleanExpression? where T : Number, T : Comparable<T> =
+    if (this == null || value == null) null else this.goe(value)
+
+/**
+ * Null-safe greater-than-or-equal against another expression, skipping when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this >= expr, or null
+ */
+infix fun <T> NumberExpression<T>?.goe(expr: Expression<T>?): BooleanExpression? where T : Number, T : Comparable<T> =
+    if (this == null || expr == null) null else this.goe(expr)
+
+/**
+ * Null-safe less-than against a value, skipping when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this < value, or null
+ */
+infix fun <T> NumberExpression<T>?.lt(value: T?): BooleanExpression? where T : Number, T : Comparable<T> =
+    if (this == null || value == null) null else this.lt(value)
+
+/**
+ * Null-safe less-than against another expression, skipping when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this < expr, or null
+ */
+infix fun <T> NumberExpression<T>?.lt(expr: Expression<T>?): BooleanExpression? where T : Number, T : Comparable<T> =
+    if (this == null || expr == null) null else this.lt(expr)
+
+/**
+ * Null-safe less-than-or-equal against a value, skipping when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this <= value, or null
+ */
+infix fun <T> NumberExpression<T>?.loe(value: T?): BooleanExpression? where T : Number, T : Comparable<T> =
+    if (this == null || value == null) null else this.loe(value)
+
+/**
+ * Null-safe less-than-or-equal against another expression, skipping when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this <= expr, or null
+ */
+infix fun <T> NumberExpression<T>?.loe(expr: Expression<T>?): BooleanExpression? where T : Number, T : Comparable<T> =
+    if (this == null || expr == null) null else this.loe(expr)

--- a/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/SimpleExpressionExtensions.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/SimpleExpressionExtensions.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.kotlin
+
+import com.querydsl.core.types.Expression
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.SimpleExpression
+
+/**
+ * Null-safe equality against a value, skipping the condition when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this = value, or null
+ */
+infix fun <T> SimpleExpression<T>?.eq(value: T?): BooleanExpression? =
+    if (this == null || value == null) null else this.eq(value)
+
+/**
+ * Null-safe equality against another expression, skipping the condition when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this = expr, or null
+ */
+infix fun <T> SimpleExpression<T>?.eq(expr: Expression<in T>?): BooleanExpression? =
+    if (this == null || expr == null) null else this.eq(expr)
+
+/**
+ * Null-safe inequality against a value, skipping the condition when either side is null.
+ *
+ * @param value the value to compare against, or null to skip
+ * @return this != value, or null
+ */
+infix fun <T> SimpleExpression<T>?.ne(value: T?): BooleanExpression? =
+    if (this == null || value == null) null else this.ne(value)
+
+/**
+ * Null-safe inequality against another expression, skipping the condition when either side is null.
+ *
+ * @param expr the expression to compare against, or null to skip
+ * @return this != expr, or null
+ */
+infix fun <T> SimpleExpression<T>?.ne(expr: Expression<in T>?): BooleanExpression? =
+    if (this == null || expr == null) null else this.ne(expr)
+
+/**
+ * Null-safe IN that skips the condition when this is null or the collection is null or empty.
+ *
+ * @param values the values to match, or null/empty to skip
+ * @return this IN values, or null
+ */
+infix fun <T> SimpleExpression<T>?.`in`(values: Collection<T>?): BooleanExpression? =
+    if (this == null || values.isNullOrEmpty()) null else this.`in`(values)

--- a/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/StringExpressionExtensions.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/main/kotlin/com/querydsl/kotlin/StringExpressionExtensions.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.kotlin
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.StringExpression
+
+/**
+ * Null-safe LIKE that skips the condition when either side is null.
+ *
+ * @param pattern the LIKE pattern, or null to skip
+ * @return this LIKE pattern, or null
+ */
+infix fun StringExpression?.like(pattern: String?): BooleanExpression? =
+    if (this == null || pattern == null) null else this.like(pattern)
+
+/**
+ * Null-safe CONTAINS that skips the condition when either side is null.
+ *
+ * @param substring the substring to match, or null to skip
+ * @return this LIKE %substring%, or null
+ */
+infix fun StringExpression?.contains(substring: String?): BooleanExpression? =
+    if (this == null || substring == null) null else this.contains(substring)
+
+/**
+ * Null-safe STARTS WITH that skips the condition when either side is null.
+ *
+ * @param prefix the prefix to match, or null to skip
+ * @return this LIKE prefix%, or null
+ */
+infix fun StringExpression?.startsWith(prefix: String?): BooleanExpression? =
+    if (this == null || prefix == null) null else this.startsWith(prefix)
+
+/**
+ * Null-safe ENDS WITH that skips the condition when either side is null.
+ *
+ * @param suffix the suffix to match, or null to skip
+ * @return this LIKE %suffix, or null
+ */
+infix fun StringExpression?.endsWith(suffix: String?): BooleanExpression? =
+    if (this == null || suffix == null) null else this.endsWith(suffix)

--- a/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/ComparableExpressionExtensionsTest.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/ComparableExpressionExtensionsTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.kotlin
+
+import com.querydsl.core.types.Expression
+import com.querydsl.core.types.dsl.ComparableExpression
+import com.querydsl.core.types.dsl.Expressions
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ComparableExpressionExtensionsTest {
+
+    private val score: ComparableExpression<Int> = Expressions.comparablePath(Int::class.javaObjectType, "score")
+    private val other: ComparableExpression<Int> = Expressions.comparablePath(Int::class.javaObjectType, "other")
+    private val nil: ComparableExpression<Int>? = null
+    private val nilValue: Int? = null
+    private val nilExpr: Expression<Int>? = null
+
+    @Test
+    fun `gt against a value covers the four null combinations`() {
+        val c: ComparableExpression<Int>? = score
+        assertEquals(score.gt(5), c.gt(5))
+        assertNull(c.gt(nilValue))
+        assertNull(nil.gt(5))
+        assertNull(nil.gt(nilValue))
+    }
+
+    @Test
+    fun `gt against an expression covers the four null combinations`() {
+        val c: ComparableExpression<Int>? = score
+        val e: Expression<Int>? = other
+        assertEquals(score.gt(other), c.gt(e))
+        assertNull(c.gt(nilExpr))
+        assertNull(nil.gt(e))
+        assertNull(nil.gt(nilExpr))
+    }
+
+    @Test
+    fun `goe against a value covers the four null combinations`() {
+        val c: ComparableExpression<Int>? = score
+        assertEquals(score.goe(5), c.goe(5))
+        assertNull(c.goe(nilValue))
+        assertNull(nil.goe(5))
+        assertNull(nil.goe(nilValue))
+    }
+
+    @Test
+    fun `goe against an expression covers the four null combinations`() {
+        val c: ComparableExpression<Int>? = score
+        val e: Expression<Int>? = other
+        assertEquals(score.goe(other), c.goe(e))
+        assertNull(c.goe(nilExpr))
+        assertNull(nil.goe(e))
+        assertNull(nil.goe(nilExpr))
+    }
+
+    @Test
+    fun `lt against a value covers the four null combinations`() {
+        val c: ComparableExpression<Int>? = score
+        assertEquals(score.lt(5), c.lt(5))
+        assertNull(c.lt(nilValue))
+        assertNull(nil.lt(5))
+        assertNull(nil.lt(nilValue))
+    }
+
+    @Test
+    fun `lt against an expression covers the four null combinations`() {
+        val c: ComparableExpression<Int>? = score
+        val e: Expression<Int>? = other
+        assertEquals(score.lt(other), c.lt(e))
+        assertNull(c.lt(nilExpr))
+        assertNull(nil.lt(e))
+        assertNull(nil.lt(nilExpr))
+    }
+
+    @Test
+    fun `loe against a value covers the four null combinations`() {
+        val c: ComparableExpression<Int>? = score
+        assertEquals(score.loe(5), c.loe(5))
+        assertNull(c.loe(nilValue))
+        assertNull(nil.loe(5))
+        assertNull(nil.loe(nilValue))
+    }
+
+    @Test
+    fun `loe against an expression covers the four null combinations`() {
+        val c: ComparableExpression<Int>? = score
+        val e: Expression<Int>? = other
+        assertEquals(score.loe(other), c.loe(e))
+        assertNull(c.loe(nilExpr))
+        assertNull(nil.loe(e))
+        assertNull(nil.loe(nilExpr))
+    }
+
+    @Test
+    fun `between judges each bound independently`() {
+        val c: ComparableExpression<Int>? = score
+        val lo: Int? = 1
+        val hi: Int? = 10
+        assertEquals(score.between(1, 10), c.between(lo to hi)) // both -> BETWEEN
+        assertEquals(score.goe(1), c.between(lo to null))       // lower-only -> >=
+        assertEquals(score.loe(10), c.between(null to hi))      // upper-only -> <=
+        assertNull(c.between(null to null))                     // neither -> skip
+        assertNull(nil.between(lo to hi))                       // this null
+    }
+
+    @Test
+    fun `notBetween mirrors between`() {
+        val c: ComparableExpression<Int>? = score
+        val lo: Int? = 1
+        val hi: Int? = 10
+        assertEquals(score.notBetween(1, 10), c.notBetween(lo to hi))
+        assertEquals(score.lt(1), c.notBetween(lo to null))
+        assertEquals(score.gt(10), c.notBetween(null to hi))
+        assertNull(c.notBetween(null to null))
+        assertNull(nil.notBetween(lo to hi))
+    }
+
+    @Test
+    fun `between with closed range`() {
+        val c: ComparableExpression<Int>? = score
+        assertEquals(score.between(20, 60), c.between(20..60))
+        assertNull(nil.between(20..60))
+    }
+}

--- a/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/ExpressionExtensionsTest.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/ExpressionExtensionsTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.kotlin
+
+import com.querydsl.core.types.Expression
+import com.querydsl.core.types.Ops
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.Expressions
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ExpressionExtensionsTest {
+
+    private val a: BooleanExpression = Expressions.booleanPath("a")
+    private val b: BooleanExpression = Expressions.booleanPath("b")
+
+    private fun nil(): Expression<Boolean>? = null
+
+    @Test
+    fun `and judges each side independently`() {
+        val an: Expression<Boolean>? = a
+        val bn: Expression<Boolean>? = b
+        assertEquals(Expressions.booleanOperation(Ops.AND, a, b), an and bn) // both -> AND
+        assertEquals(Expressions.asBoolean(a), an and null)                   // this only -> this
+        assertEquals(Expressions.asBoolean(b), nil() and bn)                  // arg only  -> arg
+        assertNull(nil() and null)                                            // neither   -> skip
+    }
+
+    @Test
+    fun `or judges each side independently`() {
+        val an: Expression<Boolean>? = a
+        val bn: Expression<Boolean>? = b
+        assertEquals(Expressions.booleanOperation(Ops.OR, a, b), an or bn)
+        assertEquals(Expressions.asBoolean(a), an or null)
+        assertEquals(Expressions.asBoolean(b), nil() or bn)
+        assertNull(nil() or null)
+    }
+
+    @Test
+    fun `xor skips when either side is null`() {
+        val an: Expression<Boolean>? = a
+        val bn: Expression<Boolean>? = b
+        assertEquals(Expressions.booleanOperation(Ops.XOR, a, b), an xor bn)
+        assertNull(an xor null)
+        assertNull(nil() xor bn)
+        assertNull(nil() xor null)
+    }
+
+    @Test
+    fun `not skips when null`() {
+        val an: Expression<Boolean>? = a
+        assertEquals(Expressions.booleanOperation(Ops.NOT, a), !an)
+        assertNull(!nil())
+    }
+
+    @Test
+    fun `non-null BooleanExpression and resolves to the member method`() {
+        val result: BooleanExpression = a.and(b) // must compile as non-null (member wins)
+        assertEquals(a.and(b), result)
+    }
+}

--- a/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/NumberExpressionExtensionsTest.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/NumberExpressionExtensionsTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.kotlin
+
+import com.querydsl.core.types.Expression
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.core.types.dsl.NumberExpression
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class NumberExpressionExtensionsTest {
+
+    private val age: NumberExpression<Int> = Expressions.numberPath(Int::class.javaObjectType, "age")
+    private val other: NumberExpression<Int> = Expressions.numberPath(Int::class.javaObjectType, "other")
+    private val nil: NumberExpression<Int>? = null
+    private val nilValue: Int? = null
+    private val nilExpr: Expression<Int>? = null
+
+    @Test
+    fun `gt against a value covers the four null combinations`() {
+        val n: NumberExpression<Int>? = age
+        assertEquals(age.gt(20), n.gt(20))
+        assertNull(n.gt(nilValue))
+        assertNull(nil.gt(20))
+        assertNull(nil.gt(nilValue))
+    }
+
+    @Test
+    fun `gt against an expression covers the four null combinations`() {
+        val n: NumberExpression<Int>? = age
+        val e: Expression<Int>? = other
+        assertEquals(age.gt(other), n.gt(e))
+        assertNull(n.gt(nilExpr))
+        assertNull(nil.gt(e))
+        assertNull(nil.gt(nilExpr))
+    }
+
+    @Test
+    fun `goe against a value covers the four null combinations`() {
+        val n: NumberExpression<Int>? = age
+        assertEquals(age.goe(20), n.goe(20))
+        assertNull(n.goe(nilValue))
+        assertNull(nil.goe(20))
+        assertNull(nil.goe(nilValue))
+    }
+
+    @Test
+    fun `goe against an expression covers the four null combinations`() {
+        val n: NumberExpression<Int>? = age
+        val e: Expression<Int>? = other
+        assertEquals(age.goe(other), n.goe(e))
+        assertNull(n.goe(nilExpr))
+        assertNull(nil.goe(e))
+        assertNull(nil.goe(nilExpr))
+    }
+
+    @Test
+    fun `lt against a value covers the four null combinations`() {
+        val n: NumberExpression<Int>? = age
+        assertEquals(age.lt(20), n.lt(20))
+        assertNull(n.lt(nilValue))
+        assertNull(nil.lt(20))
+        assertNull(nil.lt(nilValue))
+    }
+
+    @Test
+    fun `lt against an expression covers the four null combinations`() {
+        val n: NumberExpression<Int>? = age
+        val e: Expression<Int>? = other
+        assertEquals(age.lt(other), n.lt(e))
+        assertNull(n.lt(nilExpr))
+        assertNull(nil.lt(e))
+        assertNull(nil.lt(nilExpr))
+    }
+
+    @Test
+    fun `loe against a value covers the four null combinations`() {
+        val n: NumberExpression<Int>? = age
+        assertEquals(age.loe(20), n.loe(20))
+        assertNull(n.loe(nilValue))
+        assertNull(nil.loe(20))
+        assertNull(nil.loe(nilValue))
+    }
+
+    @Test
+    fun `loe against an expression covers the four null combinations`() {
+        val n: NumberExpression<Int>? = age
+        val e: Expression<Int>? = other
+        assertEquals(age.loe(other), n.loe(e))
+        assertNull(n.loe(nilExpr))
+        assertNull(nil.loe(e))
+        assertNull(nil.loe(nilExpr))
+    }
+}

--- a/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/SimpleExpressionExtensionsTest.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/SimpleExpressionExtensionsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.kotlin
+
+import com.querydsl.core.types.Expression
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.core.types.dsl.SimpleExpression
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SimpleExpressionExtensionsTest {
+
+    private val name: SimpleExpression<String> = Expressions.stringPath("name")
+    private val other: SimpleExpression<String> = Expressions.stringPath("other")
+    private val nil: SimpleExpression<String>? = null
+    private val nilValue: String? = null
+    private val nilExpr: Expression<String>? = null
+
+    @Test
+    fun `eq against a value covers the four null combinations`() {
+        val s: SimpleExpression<String>? = name
+        assertEquals(name.eq("a"), s.eq("a"))
+        assertNull(s.eq(nilValue))
+        assertNull(nil.eq("a"))
+        assertNull(nil.eq(nilValue))
+    }
+
+    @Test
+    fun `eq against an expression covers the four null combinations`() {
+        val s: SimpleExpression<String>? = name
+        val e: Expression<String>? = other
+        assertEquals(name.eq(other), s.eq(e))
+        assertNull(s.eq(nilExpr))
+        assertNull(nil.eq(e))
+        assertNull(nil.eq(nilExpr))
+    }
+
+    @Test
+    fun `ne against a value covers the four null combinations`() {
+        val s: SimpleExpression<String>? = name
+        assertEquals(name.ne("a"), s.ne("a"))
+        assertNull(s.ne(nilValue))
+        assertNull(nil.ne("a"))
+        assertNull(nil.ne(nilValue))
+    }
+
+    @Test
+    fun `ne against an expression covers the four null combinations`() {
+        val s: SimpleExpression<String>? = name
+        val e: Expression<String>? = other
+        assertEquals(name.ne(other), s.ne(e))
+        assertNull(s.ne(nilExpr))
+        assertNull(nil.ne(e))
+        assertNull(nil.ne(nilExpr))
+    }
+
+    @Test
+    fun `in covers the four null combinations plus empty`() {
+        val s: SimpleExpression<String>? = name
+        assertEquals(name.`in`(listOf("a", "b")), s.`in`(listOf("a", "b")))
+        assertNull(s.`in`(null))
+        assertNull(s.`in`(emptyList()))
+        assertNull(nil.`in`(listOf("a")))
+        assertNull(nil.`in`(null))
+    }
+}

--- a/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/StringExpressionExtensionsTest.kt
+++ b/querydsl-libraries/querydsl-kotlin/src/test/kotlin/com/querydsl/kotlin/StringExpressionExtensionsTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.querydsl.kotlin
+
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.core.types.dsl.StringExpression
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class StringExpressionExtensionsTest {
+
+    private val name: StringExpression = Expressions.stringPath("name")
+    private val nil: StringExpression? = null
+
+    @Test
+    fun `like covers the four null combinations`() {
+        val s: StringExpression? = name
+        assertEquals(name.like("%a%"), s.like("%a%"))
+        assertNull(s.like(null))
+        assertNull(nil.like("%a%"))
+        assertNull(nil.like(null))
+    }
+
+    @Test
+    fun `contains covers the four null combinations`() {
+        val s: StringExpression? = name
+        assertEquals(name.contains("a"), s.contains("a"))
+        assertNull(s.contains(null))
+        assertNull(nil.contains("a"))
+        assertNull(nil.contains(null))
+    }
+
+    @Test
+    fun `startsWith covers the four null combinations`() {
+        val s: StringExpression? = name
+        assertEquals(name.startsWith("a"), s.startsWith("a"))
+        assertNull(s.startsWith(null))
+        assertNull(nil.startsWith("a"))
+        assertNull(nil.startsWith(null))
+    }
+
+    @Test
+    fun `endsWith covers the four null combinations`() {
+        val s: StringExpression? = name
+        assertEquals(name.endsWith("z"), s.endsWith("z"))
+        assertNull(s.endsWith(null))
+        assertNull(nil.endsWith("z"))
+        assertNull(nil.endsWith(null))
+    }
+}


### PR DESCRIPTION
Fixes #1845

## Problem

Building dynamic queries in Kotlin is more verbose than in Java. `where(...)` already ignores
`null` predicates (`DefaultQueryMetadata.addWhere` returns early on `null`), but Kotlin has no
ternary operator, so an optional filter forces `if`/`else`, `?.let`, a `BooleanBuilder`, or a
per-field helper. The existing `ExpressionExtensions.kt` provides only non-null operator overloads,
which do not cover the "skip this condition when the argument is null" case that dominates
dynamic-query code.

## Approach

Null-safe infix extensions that return `null` (dropped by `where(...)`) when the receiver or the
argument is null:

```kotlin
where(
    member.name eq name,   // name: String? -> skipped when null
    member.age gt age,      // age: Int?      -> skipped when null
)
```

- New per-type files: `SimpleExpressionExtensions`, `ComparableExpressionExtensions`,
  `NumberExpressionExtensions`, `StringExpressionExtensions`.
- Each comparison/equality helper has a **value form and an expression form**
  (`gt(value)` and `gt(expr)`), covering parameter and column-to-column comparisons.
- `between` / `notBetween` support **partial ranges**: both bounds yields BETWEEN, one bound yields
  a one-sided comparison, neither is skipped. A `ClosedRange` overload (`age between (20..60)`) is
  also provided.
- The existing top-level `and` / `or` / `xor` / `xnor` / `not` in `ExpressionExtensions.kt` are
  folded into null-safe variants (`and` / `or` with partial application, the others skip on null).

## Compatibility

- **Additive**: `eq` / `ne` / `in` / `gt` / `goe` / `lt` / `loe` / `between` / `like` / `contains`
  / `startsWith` / `endsWith` reuse member-backed names, so member-over-extension keeps existing
  non-null calls intact.
- **Source-breaking**: folding `and` / `or` / `xor` / `xnor` / `not` changes their return type to
  `BooleanExpression?`. In practice `BooleanExpression.and/or/not` stay non-null via their member
  methods, so only raw `Expression<Boolean>` callers are affected. I'll leave the release and
  version placement entirely to your judgement.

## Tests

- The four null combinations (this-null / arg-null / both-null / both-non-null) per function, for
  both the value and expression overloads; partial application for `between` / `notBetween` /
  `and` / `or`.
- Non-null cases are asserted equal to the member-method result (member-over-extension check).
- Existing `CollectionTest` still passes. 39 tests total, green with the JDK 17 compile target and
  the JDK 25 build toolchain.
