### PR TITLE
ci: run no-database tests in parallel with database tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,8 +21,8 @@ env:
   ORACLE_MODULES: ":querydsl-jpa,:querydsl-sql,:querydsl-sql-codegen"
 
 jobs:
-  # Compile all core jars once (and run the database-independent unit tests), then publish
-  # the built artifacts as a per-commit cache that every downstream test job restores.
+  # Compile all core jars once (no tests), then publish the built artifacts as a per-commit
+  # cache that every downstream test job restores. Tests run in the parallel jobs below.
   compile:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
@@ -36,14 +36,38 @@ jobs:
       - name: Validate code format
         run: ./mvnw -ntp -B git-code-format:validate-code-format
 
-      - name: Build and run database-independent tests
-        run: ./mvnw -ntp -B clean install -Pno-databases
+      - name: Build (no tests)
+        run: ./mvnw -ntp -B clean install -Pno-databases -DskipTests
 
       - name: Save build artifacts
         uses: actions/cache/save@v4
         with:
           path: ~/.m2/repository/io/github/openfeign/querydsl
           key: build-artifacts-${{ github.sha }}
+
+  # Database-independent tests, run in parallel with the database test jobs.
+  no-databases:
+    if: ${{ !github.event.pull_request.draft }}
+    needs: compile
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
+      - name: Restore build artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository/io/github/openfeign/querydsl
+          key: build-artifacts-${{ github.sha }}
+      - name: Run database-independent tests
+        run: ./mvnw -ntp -B install -Deasyjacoco.skip=true -Pno-databases
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v5
+        if: always()
+        with:
+          report_paths: "**/target/surefire-reports/TEST-*.xml"
+          check_name: "Test report (no-databases)"
 
   # Compile + package only (no databases) on Windows, mirroring the previous CircleCI job.
   windows:
@@ -426,6 +450,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - compile
+      - no-databases
       - windows
       - embedded
       - mysql


### PR DESCRIPTION
`compile` previously ran `clean install -Pno-databases`, executing all database-independent tests on the critical path — every database test job `needs: compile` and had to wait for those tests before starting.

Changes:
- `compile` now builds only (`-DskipTests`) and publishes the artifact cache — no tests.
- New `no-databases` job runs the database-independent tests, restoring the cache, in parallel with the database test jobs.
- Added `no-databases` to the `build` aggregate (the required status check).

Net effect: the database jobs no longer wait on the unit-test suite, and the no-database tests run concurrently with them.