### PR TITLE
Performance: use ArrayList for serializer constants

### DIFF
--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/support/SerializerBase.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/support/SerializerBase.java
@@ -27,11 +27,11 @@ import com.querydsl.core.types.Template;
 import com.querydsl.core.types.TemplateExpression;
 import com.querydsl.core.types.Templates;
 import com.querydsl.core.types.Visitor;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.IdentityHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,7 +64,7 @@ public abstract class SerializerBase<S extends SerializerBase<S>> implements Vis
 
   private String anonParamPrefix = "_";
 
-  protected final List<Object> constants = new LinkedList<>();
+  protected final List<Object> constants = new ArrayList<>();
 
   protected final Map<Object, String> constantToLabel = new IdentityHashMap<>();
 


### PR DESCRIPTION
# Use `ArrayList` for serializer constants

## Summary

Replace the `LinkedList` implementation used by `SerializerBase.constants` with `ArrayList`.

## Motivation

Serializer constants are only appended to, indexed, and iterated during query serialization. `ArrayList` is a better fit for this access pattern because it provides contiguous storage, lower per-element memory overhead, and efficient indexed access.

## Scope

- Preserve the existing `List<Object>` API.
- Preserve constant ordering and parameter indexes.
- Remove the unused `LinkedList` import.
- Make no behavioral changes to serialization.