### PR TITLE
Auto-convert @Enumerated values in native JPA INSERT paths (#1883)

### DIFF
--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JpaInsertNativeHelper.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/JpaInsertNativeHelper.java
@@ -13,12 +13,17 @@
  */
 package com.querydsl.jpa;
 
+import com.querydsl.core.types.Constant;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ParamExpression;
 import com.querydsl.core.types.ParamNotSetException;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.Param;
+import jakarta.persistence.Convert;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.lang.reflect.AnnotatedElement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -90,6 +95,97 @@ public final class JpaInsertNativeHelper {
       } else {
         result.add(Expressions.constant(v));
       }
+    }
+    return result;
+  }
+
+  /**
+   * Apply JPA {@code @Enumerated} conversion to any {@link Constant} whose value is an {@link Enum}
+   * and whose target column carries {@code @Enumerated} on its annotated element.
+   *
+   * <p>Because the native SQL path binds values directly via {@link
+   * PreparedStatement#setObject(int, Object)} instead of going through JPA, enum values would
+   * otherwise be handed to the JDBC driver as-is, producing driver-dependent behavior. This helper
+   * normalizes them according to the entity's mapping annotations so the same rules Hibernate would
+   * apply on the JPQL path are honored on the native path too.
+   *
+   * <ul>
+   *   <li>{@code @Enumerated(EnumType.STRING)} — bind {@code enum.name()}
+   *   <li>{@code @Enumerated(EnumType.ORDINAL)} — bind {@code enum.ordinal()}
+   *   <li>Enum field with no {@code @Enumerated} annotation — bind {@code enum.ordinal()} (JPA
+   *       specification default)
+   *   <li>{@code @Convert(converter = ...)} on an enum field — throw {@link IllegalStateException}
+   *       with an actionable message; custom {@code AttributeConverter} instances cannot be honored
+   *       on a native path that bypasses JPA
+   * </ul>
+   *
+   * <p>Non-enum values, expression templates that do not resolve to a bare {@link Enum}, and
+   * columns whose target does not expose an annotated element are returned unchanged.
+   *
+   * @param columns column paths, positionally paired with {@code values}
+   * @param values value expressions to normalize
+   * @return a new list of expressions with enum conversion applied where appropriate
+   * @throws IllegalStateException if an enum field is mapped with {@code @Convert}
+   */
+  public static List<Expression<?>> convertEnumValues(
+      List<Path<?>> columns, List<Expression<?>> values) {
+    if (columns.size() != values.size()) {
+      return values;
+    }
+    var result = new ArrayList<Expression<?>>(values.size());
+    for (var i = 0; i < values.size(); i++) {
+      result.add(convertEnumValue(columns.get(i), values.get(i)));
+    }
+    return result;
+  }
+
+  private static Expression<?> convertEnumValue(Path<?> column, Expression<?> value) {
+    if (!(value instanceof Constant<?> constant)) {
+      return value;
+    }
+    var raw = constant.getConstant();
+    if (!(raw instanceof Enum<?> enumValue)) {
+      return value;
+    }
+    var annotated = column.getAnnotatedElement();
+    if (annotated == null) {
+      return value;
+    }
+    if (annotated.isAnnotationPresent(Convert.class)) {
+      throw new IllegalStateException(
+          "Column '"
+              + column
+              + "' is mapped with @Convert on an enum field. Custom AttributeConverters cannot be"
+              + " honored on the native SQL INSERT path (executeWithKey/executeWithKeys/multi-row"
+              + " execute) because it bypasses the JPA layer. Convert the value at the call site,"
+              + " e.g. .set(path, myConverter.convertToDatabaseColumn(value)).");
+    }
+    var enumType = resolveEnumType(annotated);
+    return switch (enumType) {
+      case STRING -> Expressions.constant(enumValue.name());
+      case ORDINAL -> Expressions.constant(enumValue.ordinal());
+    };
+  }
+
+  private static EnumType resolveEnumType(AnnotatedElement annotated) {
+    if (annotated.isAnnotationPresent(Enumerated.class)) {
+      return annotated.getAnnotation(Enumerated.class).value();
+    }
+    return EnumType.ORDINAL;
+  }
+
+  /**
+   * Apply {@link #convertEnumValues(List, List)} to every row of a multi-row INSERT.
+   *
+   * @param columns column paths shared by every row
+   * @param rows rows of value expressions to normalize
+   * @return a new list of rows with enum conversion applied
+   */
+  public static List<List<Expression<?>>> convertEnumValuesForRows(
+      List<Path<?>> columns, List<List<Expression<?>>> rows) {
+    var result = new ArrayList<List<Expression<?>>>(rows.size());
+    for (var row : rows) {
+      result.add(convertEnumValues(columns, row));
     }
     return result;
   }

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateInsertClause.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/hibernate/HibernateInsertClause.java
@@ -126,7 +126,9 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
     if (effectiveColumns.isEmpty()) {
       throw new IllegalStateException("No columns specified for insert");
     }
-    var effectiveValues = JpaInsertNativeHelper.effectiveValues(inserts, values);
+    var effectiveValues =
+        JpaInsertNativeHelper.convertEnumValues(
+            effectiveColumns, JpaInsertNativeHelper.effectiveValues(inserts, values));
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
@@ -171,6 +173,8 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
     if (!values.isEmpty() || !inserts.isEmpty()) {
       allRows.add(JpaInsertNativeHelper.effectiveValues(inserts, values));
     }
+    allRows =
+        new ArrayList<>(JpaInsertNativeHelper.convertEnumValuesForRows(effectiveColumns, allRows));
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
@@ -257,7 +261,9 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
     if (effectiveColumns.isEmpty()) {
       throw new IllegalStateException("No columns specified for insert");
     }
-    var effectiveValues = JpaInsertNativeHelper.effectiveValues(inserts, values);
+    var effectiveValues =
+        JpaInsertNativeHelper.convertEnumValues(
+            effectiveColumns, JpaInsertNativeHelper.effectiveValues(inserts, values));
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
@@ -357,6 +363,8 @@ public class HibernateInsertClause implements InsertClause<HibernateInsertClause
     if (allRows.isEmpty()) {
       throw new IllegalStateException("No values specified for insert");
     }
+    allRows =
+        new ArrayList<>(JpaInsertNativeHelper.convertEnumValuesForRows(effectiveColumns, allRows));
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 

--- a/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAInsertClause.java
+++ b/querydsl-libraries/querydsl-jpa/src/main/java/com/querydsl/jpa/impl/JPAInsertClause.java
@@ -111,7 +111,9 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
     if (effectiveColumns.isEmpty()) {
       throw new IllegalStateException("No columns specified for insert");
     }
-    var effectiveValues = JpaInsertNativeHelper.effectiveValues(inserts, values);
+    var effectiveValues =
+        JpaInsertNativeHelper.convertEnumValues(
+            effectiveColumns, JpaInsertNativeHelper.effectiveValues(inserts, values));
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
@@ -155,6 +157,8 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
     if (!values.isEmpty() || !inserts.isEmpty()) {
       allRows.add(JpaInsertNativeHelper.effectiveValues(inserts, values));
     }
+    allRows =
+        new ArrayList<>(JpaInsertNativeHelper.convertEnumValuesForRows(effectiveColumns, allRows));
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
@@ -239,7 +243,9 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
     if (effectiveColumns.isEmpty()) {
       throw new IllegalStateException("No columns specified for insert");
     }
-    var effectiveValues = JpaInsertNativeHelper.effectiveValues(inserts, values);
+    var effectiveValues =
+        JpaInsertNativeHelper.convertEnumValues(
+            effectiveColumns, JpaInsertNativeHelper.effectiveValues(inserts, values));
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 
@@ -340,6 +346,8 @@ public class JPAInsertClause implements InsertClause<JPAInsertClause> {
     if (allRows.isEmpty()) {
       throw new IllegalStateException("No values specified for insert");
     }
+    allRows =
+        new ArrayList<>(JpaInsertNativeHelper.convertEnumValuesForRows(effectiveColumns, allRows));
 
     var entityClass = queryMixin.getMetadata().getJoins().get(0).getTarget().getType();
 

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateExecuteWithKeyTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/HibernateExecuteWithKeyTest.java
@@ -296,6 +296,337 @@ public class HibernateExecuteWithKeyTest {
   }
 
   @Test
+  public void enum_string_column_stored_as_name() {
+    // #1883: @Enumerated(EnumType.STRING) fields should be bound as enum.name()
+    // on the native path, not left to driver behavior.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "enum-string")
+            .set(entity.statusString, GeneratedKeyEntity.Status.ACTIVE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (String)
+            session
+                .createNativeQuery(
+                    "select status_string_ from generated_key_entity where id = ?1", String.class)
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored).isEqualTo("ACTIVE");
+  }
+
+  @Test
+  public void enum_ordinal_column_stored_as_ordinal() {
+    // #1883: @Enumerated(EnumType.ORDINAL) fields should be bound as enum.ordinal().
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "enum-ordinal")
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        session
+            .createNativeQuery(
+                "select status_ordinal_ from generated_key_entity where id = ?1", Integer.class)
+            .setParameter(1, id)
+            .getSingleResult();
+    assertThat(stored).isEqualTo(GeneratedKeyEntity.Status.DONE.ordinal());
+  }
+
+  @Test
+  public void enum_default_annotation_stored_as_ordinal() {
+    // #1883: An enum field without @Enumerated defaults to ORDINAL per JPA spec.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "enum-default")
+            .set(entity.statusDefault, GeneratedKeyEntity.Status.PENDING)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        session
+            .createNativeQuery(
+                "select status_default_ from generated_key_entity where id = ?1", Integer.class)
+            .setParameter(1, id)
+            .getSingleResult();
+    assertThat(stored).isEqualTo(GeneratedKeyEntity.Status.PENDING.ordinal());
+  }
+
+  @Test
+  public void enum_with_convert_fails_fast() {
+    // #1883: @Convert on an enum field cannot be honored on the native path
+    // (which bypasses JPA). Fail-fast with a clear message.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    assertThatThrownBy(
+            () ->
+                insert(entity)
+                    .set(entity.name, "enum-convert")
+                    .set(entity.statusConverted, GeneratedKeyEntity.Status.ACTIVE)
+                    .executeWithKey(entity.id))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("@Convert")
+        .hasMessageContaining("convertToDatabaseColumn");
+  }
+
+  @Test
+  public void priority_ordinal_stored_as_numeric_position() {
+    // #1883: Any enum mapped with EnumType.ORDINAL — not just Status — is bound
+    // as its integer position, verifying the conversion is generic across enums.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "prio-ordinal")
+            .set(entity.priorityOrdinal, GeneratedKeyEntity.Priority.CRITICAL)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        session
+            .createNativeQuery(
+                "select priority_ordinal_ from generated_key_entity where id = ?1", Integer.class)
+            .setParameter(1, id)
+            .getSingleResult();
+    assertThat(stored).isEqualTo(3);
+    assertThat(stored).isEqualTo(GeneratedKeyEntity.Priority.CRITICAL.ordinal());
+  }
+
+  @Test
+  public void priority_string_stored_as_name() {
+    // #1883: The same Priority enum mapped with EnumType.STRING stores its name(),
+    // verifying the STRING branch also works for enums beyond Status.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "prio-string")
+            .set(entity.priorityString, GeneratedKeyEntity.Priority.MEDIUM)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (String)
+            session
+                .createNativeQuery(
+                    "select priority_string_ from generated_key_entity where id = ?1", String.class)
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored).isEqualTo("MEDIUM");
+  }
+
+  @Test
+  public void enum_ordinal_multi_row_with_addRow_stores_numeric_values() {
+    // #1883: Enum conversion for @Enumerated(EnumType.ORDINAL) must also apply
+    // across multi-row INSERTs — every row is bound as enum.ordinal().
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    long rows =
+        insert(entity)
+            .set(entity.name, "ord-1")
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.PENDING)
+            .addRow()
+            .set(entity.name, "ord-2")
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.ACTIVE)
+            .addRow()
+            .set(entity.name, "ord-3")
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .execute();
+
+    assertThat(rows).isEqualTo(3L);
+
+    var stored =
+        session
+            .createNativeQuery(
+                "select status_ordinal_ from generated_key_entity where name_ like 'ord-%'"
+                    + " order by name_",
+                Integer.class)
+            .getResultList();
+    assertThat(stored)
+        .containsExactly(
+            GeneratedKeyEntity.Status.PENDING.ordinal(),
+            GeneratedKeyEntity.Status.ACTIVE.ordinal(),
+            GeneratedKeyEntity.Status.DONE.ordinal());
+  }
+
+  @Test
+  public void enum_ordinal_columns_values_style_also_converts_to_ordinal() {
+    // #1883: Enum conversion for @Enumerated(EnumType.ORDINAL) must apply to
+    // columns()/values() style as well as set() style.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .columns(entity.name, entity.statusOrdinal)
+            .values("cv-ordinal", GeneratedKeyEntity.Status.ACTIVE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        session
+            .createNativeQuery(
+                "select status_ordinal_ from generated_key_entity where id = ?1", Integer.class)
+            .setParameter(1, id)
+            .getSingleResult();
+    assertThat(stored).isEqualTo(GeneratedKeyEntity.Status.ACTIVE.ordinal());
+  }
+
+  @Test
+  public void enum_mixed_string_and_ordinal_in_same_row() {
+    // #1883: STRING and ORDINAL enum columns can coexist in one INSERT and each
+    // must be converted according to its own annotation.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "mixed")
+            .set(entity.statusString, GeneratedKeyEntity.Status.PENDING)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stringVal =
+        (String)
+            session
+                .createNativeQuery(
+                    "select status_string_ from generated_key_entity where id = ?1", String.class)
+                .setParameter(1, id)
+                .getSingleResult();
+    var ordinalVal =
+        session
+            .createNativeQuery(
+                "select status_ordinal_ from generated_key_entity where id = ?1", Integer.class)
+            .setParameter(1, id)
+            .getSingleResult();
+    assertThat(stringVal).isEqualTo("PENDING");
+    assertThat(ordinalVal).isEqualTo(GeneratedKeyEntity.Status.DONE.ordinal());
+  }
+
+  @Test
+  public void enum_multi_row_with_addRow_stores_all_rows_correctly() {
+    // #1883: Enum conversion must apply to every row of a multi-row INSERT.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    long rows =
+        insert(entity)
+            .set(entity.name, "mr-1")
+            .set(entity.statusString, GeneratedKeyEntity.Status.PENDING)
+            .addRow()
+            .set(entity.name, "mr-2")
+            .set(entity.statusString, GeneratedKeyEntity.Status.ACTIVE)
+            .addRow()
+            .set(entity.name, "mr-3")
+            .set(entity.statusString, GeneratedKeyEntity.Status.DONE)
+            .execute();
+
+    assertThat(rows).isEqualTo(3L);
+
+    var stored =
+        session
+            .createNativeQuery(
+                "select status_string_ from generated_key_entity where name_ like 'mr-%'"
+                    + " order by name_",
+                String.class)
+            .getResultList();
+    assertThat(stored).containsExactly("PENDING", "ACTIVE", "DONE");
+  }
+
+  @Test
+  public void enum_columns_values_style_also_converts() {
+    // #1883: Enum conversion must apply to columns()/values() style, not only set() style.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .columns(entity.name, entity.statusString)
+            .values("cv-style", GeneratedKeyEntity.Status.ACTIVE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (String)
+            session
+                .createNativeQuery(
+                    "select status_string_ from generated_key_entity where id = ?1", String.class)
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored).isEqualTo("ACTIVE");
+  }
+
+  @Test
+  public void executeWithKeys_single_row_with_enum_returns_key_and_stores_name() {
+    // #1883: executeWithKeys() single-row path must also apply enum conversion.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var keys =
+        insert(entity)
+            .set(entity.name, "ewks-single")
+            .set(entity.statusString, GeneratedKeyEntity.Status.ACTIVE)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .executeWithKeys(entity.id);
+
+    assertThat(keys).hasSize(1);
+    var id = keys.get(0);
+    var stringVal =
+        (String)
+            session
+                .createNativeQuery(
+                    "select status_string_ from generated_key_entity where id = ?1", String.class)
+                .setParameter(1, id)
+                .getSingleResult();
+    var ordinalVal =
+        session
+            .createNativeQuery(
+                "select status_ordinal_ from generated_key_entity where id = ?1", Integer.class)
+            .setParameter(1, id)
+            .getSingleResult();
+    assertThat(stringVal).isEqualTo("ACTIVE");
+    assertThat(ordinalVal).isEqualTo(GeneratedKeyEntity.Status.DONE.ordinal());
+  }
+
+  @Test
+  public void executeWithKeys_multi_row_addRow_with_enum_returns_all_keys_and_stores_correctly() {
+    // #1883: executeWithKeys() multi-row (addRow) path must apply enum conversion
+    // to every row and return one key per inserted row.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var keys =
+        insert(entity)
+            .set(entity.name, "ewks-mr-1")
+            .set(entity.statusString, GeneratedKeyEntity.Status.PENDING)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.PENDING)
+            .addRow()
+            .set(entity.name, "ewks-mr-2")
+            .set(entity.statusString, GeneratedKeyEntity.Status.ACTIVE)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.ACTIVE)
+            .addRow()
+            .set(entity.name, "ewks-mr-3")
+            .set(entity.statusString, GeneratedKeyEntity.Status.DONE)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .executeWithKeys(entity.id);
+
+    assertThat(keys).hasSize(3);
+    assertThat(keys.get(0)).isLessThan(keys.get(1));
+    assertThat(keys.get(1)).isLessThan(keys.get(2));
+
+    var storedStrings =
+        session
+            .createNativeQuery(
+                "select status_string_ from generated_key_entity where name_ like 'ewks-mr-%'"
+                    + " order by name_",
+                String.class)
+            .getResultList();
+    var storedOrdinals =
+        session
+            .createNativeQuery(
+                "select status_ordinal_ from generated_key_entity where name_ like 'ewks-mr-%'"
+                    + " order by name_",
+                Integer.class)
+            .getResultList();
+    assertThat(storedStrings).containsExactly("PENDING", "ACTIVE", "DONE");
+    assertThat(storedOrdinals)
+        .containsExactly(
+            GeneratedKeyEntity.Status.PENDING.ordinal(),
+            GeneratedKeyEntity.Status.ACTIVE.ordinal(),
+            GeneratedKeyEntity.Status.DONE.ordinal());
+  }
+
+  @Test
   public void execute_without_template_uses_jpql_path() {
     // Regression for #1757: plain value INSERTs must keep using the JPQL path so
     // JPA semantics (cascade, callbacks where applicable) are preserved.

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAExecuteWithKeyTest.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/JPAExecuteWithKeyTest.java
@@ -18,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.domain.GeneratedKeyEntity;
+import com.querydsl.jpa.domain.GeneratedKeyStatusCodeConverter;
 import com.querydsl.jpa.domain.QGeneratedKeyEntity;
 import com.querydsl.jpa.impl.JPAInsertClause;
 import jakarta.persistence.EntityManager;
@@ -312,6 +314,372 @@ public class JPAExecuteWithKeyTest {
 
     assertThat(keys).hasSize(2);
     assertThat(keys.get(0)).isLessThan(keys.get(1));
+  }
+
+  @Test
+  public void enum_string_column_stored_as_name() {
+    // #1883: @Enumerated(EnumType.STRING) fields should be bound as enum.name()
+    // on the native path, not left to driver behavior.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "enum-string")
+            .set(entity.statusString, GeneratedKeyEntity.Status.ACTIVE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (String)
+            entityManager
+                .createNativeQuery("select status_string_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored).isEqualTo("ACTIVE");
+  }
+
+  @Test
+  public void enum_ordinal_column_stored_as_ordinal() {
+    // #1883: @Enumerated(EnumType.ORDINAL) fields should be bound as enum.ordinal().
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "enum-ordinal")
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (Number)
+            entityManager
+                .createNativeQuery("select status_ordinal_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored.intValue()).isEqualTo(GeneratedKeyEntity.Status.DONE.ordinal());
+  }
+
+  @Test
+  public void enum_default_annotation_stored_as_ordinal() {
+    // #1883: An enum field without @Enumerated defaults to ORDINAL per JPA spec.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "enum-default")
+            .set(entity.statusDefault, GeneratedKeyEntity.Status.PENDING)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (Number)
+            entityManager
+                .createNativeQuery("select status_default_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored.intValue()).isEqualTo(GeneratedKeyEntity.Status.PENDING.ordinal());
+  }
+
+  @Test
+  public void enum_with_convert_fails_fast() {
+    // #1883: @Convert on an enum field cannot be honored on the native path
+    // (which bypasses JPA). Fail-fast with a clear message pointing the caller
+    // to convert the value at the call site.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    assertThatThrownBy(
+            () ->
+                insert(entity)
+                    .set(entity.name, "enum-convert")
+                    .set(entity.statusConverted, GeneratedKeyEntity.Status.ACTIVE)
+                    .executeWithKey(entity.id))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("@Convert")
+        .hasMessageContaining("convertToDatabaseColumn");
+  }
+
+  @Test
+  public void enum_with_convert_still_works_when_value_pre_converted_at_call_site() {
+    // #1883: The documented workaround for @Convert enum fields is to convert the value
+    // at the call site. Cast the strongly-typed EnumPath to Path<String> to satisfy the
+    // compiler, then bind the converter output directly.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    var statusConvertedAsString =
+        (com.querydsl.core.types.Path<String>)
+            (com.querydsl.core.types.Path) entity.statusConverted;
+    var converter = new GeneratedKeyStatusCodeConverter();
+    Long id =
+        insert(entity)
+            .set(entity.name, "enum-convert-workaround")
+            .set(
+                statusConvertedAsString,
+                converter.convertToDatabaseColumn(GeneratedKeyEntity.Status.DONE))
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (String)
+            entityManager
+                .createNativeQuery(
+                    "select status_converted_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored).isEqualTo("code_DONE");
+  }
+
+  @Test
+  public void enum_multi_row_with_addRow_stores_all_rows_correctly() {
+    // #1883: Enum conversion must apply to every row of a multi-row INSERT.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    long rows =
+        insert(entity)
+            .set(entity.name, "mr-1")
+            .set(entity.statusString, GeneratedKeyEntity.Status.PENDING)
+            .addRow()
+            .set(entity.name, "mr-2")
+            .set(entity.statusString, GeneratedKeyEntity.Status.ACTIVE)
+            .addRow()
+            .set(entity.name, "mr-3")
+            .set(entity.statusString, GeneratedKeyEntity.Status.DONE)
+            .execute();
+
+    assertThat(rows).isEqualTo(3L);
+
+    @SuppressWarnings("unchecked")
+    var stored =
+        (java.util.List<String>)
+            entityManager
+                .createNativeQuery(
+                    "select status_string_ from generated_key_entity where name_ like 'mr-%'"
+                        + " order by name_")
+                .getResultList();
+    assertThat(stored).containsExactly("PENDING", "ACTIVE", "DONE");
+  }
+
+  @Test
+  public void enum_ordinal_multi_row_with_addRow_stores_numeric_values() {
+    // #1883: Enum conversion for @Enumerated(EnumType.ORDINAL) must also apply
+    // across multi-row INSERTs — every row is bound as enum.ordinal().
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    long rows =
+        insert(entity)
+            .set(entity.name, "ord-1")
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.PENDING)
+            .addRow()
+            .set(entity.name, "ord-2")
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.ACTIVE)
+            .addRow()
+            .set(entity.name, "ord-3")
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .execute();
+
+    assertThat(rows).isEqualTo(3L);
+
+    @SuppressWarnings("unchecked")
+    var stored =
+        (java.util.List<Number>)
+            entityManager
+                .createNativeQuery(
+                    "select status_ordinal_ from generated_key_entity where name_ like 'ord-%'"
+                        + " order by name_")
+                .getResultList();
+    assertThat(stored)
+        .extracting(Number::intValue)
+        .containsExactly(
+            GeneratedKeyEntity.Status.PENDING.ordinal(),
+            GeneratedKeyEntity.Status.ACTIVE.ordinal(),
+            GeneratedKeyEntity.Status.DONE.ordinal());
+  }
+
+  @Test
+  public void enum_ordinal_columns_values_style_also_converts_to_ordinal() {
+    // #1883: Enum conversion for @Enumerated(EnumType.ORDINAL) must apply to
+    // columns()/values() style as well as set() style.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .columns(entity.name, entity.statusOrdinal)
+            .values("cv-ordinal", GeneratedKeyEntity.Status.ACTIVE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (Number)
+            entityManager
+                .createNativeQuery("select status_ordinal_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored.intValue()).isEqualTo(GeneratedKeyEntity.Status.ACTIVE.ordinal());
+  }
+
+  @Test
+  public void priority_ordinal_stored_as_numeric_position() {
+    // #1883: Any enum mapped with EnumType.ORDINAL — not just Status — is bound
+    // as its integer position, verifying the conversion is generic across enums.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "prio-ordinal")
+            .set(entity.priorityOrdinal, GeneratedKeyEntity.Priority.CRITICAL)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (Number)
+            entityManager
+                .createNativeQuery(
+                    "select priority_ordinal_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    // CRITICAL is the 4th constant (index 3) — this is the value that lands in the DB.
+    assertThat(stored.intValue()).isEqualTo(3);
+    assertThat(stored.intValue()).isEqualTo(GeneratedKeyEntity.Priority.CRITICAL.ordinal());
+  }
+
+  @Test
+  public void priority_string_stored_as_name() {
+    // #1883: The same Priority enum mapped with EnumType.STRING stores its name(),
+    // verifying the STRING branch also works for enums beyond Status.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "prio-string")
+            .set(entity.priorityString, GeneratedKeyEntity.Priority.MEDIUM)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (String)
+            entityManager
+                .createNativeQuery(
+                    "select priority_string_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored).isEqualTo("MEDIUM");
+  }
+
+  @Test
+  public void enum_mixed_string_and_ordinal_in_same_row() {
+    // #1883: STRING and ORDINAL enum columns can coexist in one INSERT and each
+    // must be converted according to its own annotation.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .set(entity.name, "mixed")
+            .set(entity.statusString, GeneratedKeyEntity.Status.PENDING)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stringVal =
+        (String)
+            entityManager
+                .createNativeQuery("select status_string_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    var ordinalVal =
+        (Number)
+            entityManager
+                .createNativeQuery("select status_ordinal_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stringVal).isEqualTo("PENDING");
+    assertThat(ordinalVal.intValue()).isEqualTo(GeneratedKeyEntity.Status.DONE.ordinal());
+  }
+
+  @Test
+  public void enum_columns_values_style_also_converts() {
+    // #1883: Enum conversion must apply to columns()/values() style, not only set() style.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    Long id =
+        insert(entity)
+            .columns(entity.name, entity.statusString)
+            .values("cv-style", GeneratedKeyEntity.Status.ACTIVE)
+            .executeWithKey(entity.id);
+
+    assertThat(id).isNotNull();
+    var stored =
+        (String)
+            entityManager
+                .createNativeQuery("select status_string_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stored).isEqualTo("ACTIVE");
+  }
+
+  @Test
+  public void executeWithKeys_single_row_with_enum_returns_key_and_stores_name() {
+    // #1883: executeWithKeys() single-row path must also apply enum conversion.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var keys =
+        insert(entity)
+            .set(entity.name, "ewks-single")
+            .set(entity.statusString, GeneratedKeyEntity.Status.ACTIVE)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .executeWithKeys(entity.id);
+
+    assertThat(keys).hasSize(1);
+    var id = keys.get(0);
+    var stringVal =
+        (String)
+            entityManager
+                .createNativeQuery("select status_string_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    var ordinalVal =
+        (Number)
+            entityManager
+                .createNativeQuery("select status_ordinal_ from generated_key_entity where id = ?1")
+                .setParameter(1, id)
+                .getSingleResult();
+    assertThat(stringVal).isEqualTo("ACTIVE");
+    assertThat(ordinalVal.intValue()).isEqualTo(GeneratedKeyEntity.Status.DONE.ordinal());
+  }
+
+  @Test
+  public void executeWithKeys_multi_row_addRow_with_enum_returns_all_keys_and_stores_correctly() {
+    // #1883: executeWithKeys() multi-row (addRow) path must apply enum conversion
+    // to every row and return one key per inserted row.
+    var entity = QGeneratedKeyEntity.generatedKeyEntity;
+    var keys =
+        insert(entity)
+            .set(entity.name, "ewks-mr-1")
+            .set(entity.statusString, GeneratedKeyEntity.Status.PENDING)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.PENDING)
+            .addRow()
+            .set(entity.name, "ewks-mr-2")
+            .set(entity.statusString, GeneratedKeyEntity.Status.ACTIVE)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.ACTIVE)
+            .addRow()
+            .set(entity.name, "ewks-mr-3")
+            .set(entity.statusString, GeneratedKeyEntity.Status.DONE)
+            .set(entity.statusOrdinal, GeneratedKeyEntity.Status.DONE)
+            .executeWithKeys(entity.id);
+
+    assertThat(keys).hasSize(3);
+    assertThat(keys.get(0)).isLessThan(keys.get(1));
+    assertThat(keys.get(1)).isLessThan(keys.get(2));
+
+    @SuppressWarnings("unchecked")
+    var storedStrings =
+        (java.util.List<String>)
+            entityManager
+                .createNativeQuery(
+                    "select status_string_ from generated_key_entity where name_ like 'ewks-mr-%'"
+                        + " order by name_")
+                .getResultList();
+    @SuppressWarnings("unchecked")
+    var storedOrdinals =
+        (java.util.List<Number>)
+            entityManager
+                .createNativeQuery(
+                    "select status_ordinal_ from generated_key_entity where name_ like 'ewks-mr-%'"
+                        + " order by name_")
+                .getResultList();
+    assertThat(storedStrings).containsExactly("PENDING", "ACTIVE", "DONE");
+    assertThat(storedOrdinals)
+        .extracting(Number::intValue)
+        .containsExactly(
+            GeneratedKeyEntity.Status.PENDING.ordinal(),
+            GeneratedKeyEntity.Status.ACTIVE.ordinal(),
+            GeneratedKeyEntity.Status.DONE.ordinal());
   }
 
   @Test

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/GeneratedKeyEntity.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/GeneratedKeyEntity.java
@@ -1,7 +1,10 @@
 package com.querydsl.jpa.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -15,12 +18,50 @@ public class GeneratedKeyEntity implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;
 
+  public enum Status {
+    PENDING,
+    ACTIVE,
+    DONE
+  }
+
+  /** A second enum used to reinforce ORDINAL (numeric) storage tests. */
+  public enum Priority {
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL
+  }
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @Column(name = "name_")
   private String name;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status_string_", length = 32)
+  private Status statusString;
+
+  @Enumerated(EnumType.ORDINAL)
+  @Column(name = "status_ordinal_")
+  private Status statusOrdinal;
+
+  /** No {@code @Enumerated}: JPA default is {@link EnumType#ORDINAL}. */
+  @Column(name = "status_default_")
+  private Status statusDefault;
+
+  @Convert(converter = GeneratedKeyStatusCodeConverter.class)
+  @Column(name = "status_converted_", length = 32)
+  private Status statusConverted;
+
+  @Enumerated(EnumType.ORDINAL)
+  @Column(name = "priority_ordinal_")
+  private Priority priorityOrdinal;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "priority_string_", length = 16)
+  private Priority priorityString;
 
   public Long getId() {
     return id;
@@ -36,5 +77,53 @@ public class GeneratedKeyEntity implements Serializable {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public Status getStatusString() {
+    return statusString;
+  }
+
+  public void setStatusString(Status statusString) {
+    this.statusString = statusString;
+  }
+
+  public Status getStatusOrdinal() {
+    return statusOrdinal;
+  }
+
+  public void setStatusOrdinal(Status statusOrdinal) {
+    this.statusOrdinal = statusOrdinal;
+  }
+
+  public Status getStatusDefault() {
+    return statusDefault;
+  }
+
+  public void setStatusDefault(Status statusDefault) {
+    this.statusDefault = statusDefault;
+  }
+
+  public Status getStatusConverted() {
+    return statusConverted;
+  }
+
+  public void setStatusConverted(Status statusConverted) {
+    this.statusConverted = statusConverted;
+  }
+
+  public Priority getPriorityOrdinal() {
+    return priorityOrdinal;
+  }
+
+  public void setPriorityOrdinal(Priority priorityOrdinal) {
+    this.priorityOrdinal = priorityOrdinal;
+  }
+
+  public Priority getPriorityString() {
+    return priorityString;
+  }
+
+  public void setPriorityString(Priority priorityString) {
+    this.priorityString = priorityString;
   }
 }

--- a/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/GeneratedKeyStatusCodeConverter.java
+++ b/querydsl-libraries/querydsl-jpa/src/test/java/com/querydsl/jpa/domain/GeneratedKeyStatusCodeConverter.java
@@ -1,0 +1,30 @@
+package com.querydsl.jpa.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * AttributeConverter used by {@link GeneratedKeyEntity#getStatusConverted()} to verify that the
+ * native INSERT path fails fast when an enum column is mapped with {@code @Convert} (custom
+ * converters cannot be honored on the native path that bypasses JPA).
+ *
+ * <p>Kept as a top-level class so EclipseLink can discover the converter type via reflection during
+ * persistence-unit predeployment.
+ */
+@Converter
+public class GeneratedKeyStatusCodeConverter
+    implements AttributeConverter<GeneratedKeyEntity.Status, String> {
+
+  @Override
+  public String convertToDatabaseColumn(GeneratedKeyEntity.Status attribute) {
+    return attribute == null ? null : "code_" + attribute.name();
+  }
+
+  @Override
+  public GeneratedKeyEntity.Status convertToEntityAttribute(String dbData) {
+    if (dbData == null || !dbData.startsWith("code_")) {
+      return null;
+    }
+    return GeneratedKeyEntity.Status.valueOf(dbData.substring("code_".length()));
+  }
+}


### PR DESCRIPTION
## Summary

Closes #1883.

`JPAInsertClause` / `HibernateInsertClause` route through a native SQL path for `executeWithKey(...)`, `executeWithKeys(...)`, and multi-row `execute()` (accumulated via `addRow()`). On that path, enum values passed to `set(EnumPath<E>, E)` or `values(E)` were handed to `PreparedStatement.setObject(...)` as-is, so how they got stored depended entirely on the JDBC driver — MySQL usually stored `.name()` by accident, but H2 / HSQLDB / other drivers could fail or store the wrong representation.

The native path now inspects the target column's `@Enumerated` annotation and converts enum values before binding.

## Behavioral changes

- `@Enumerated(EnumType.STRING)` → bind `enum.name()`
- `@Enumerated(EnumType.ORDINAL)` → bind `enum.ordinal()`
- Enum field with no `@Enumerated` → bind `enum.ordinal()` (JPA specification default)
- `@Convert(converter = ...)` on an enum field → `IllegalStateException` with a message pointing the caller to convert the value themselves at the call site (custom `AttributeConverter` instances cannot be honored on a native path that bypasses JPA)

Conversion is applied uniformly to both `set(path, value)` and `columns(...).values(value)` call shapes, and to every row of a multi-row INSERT accumulated via `addRow()`. The JPQL path (single-row `execute()` without templates, UPDATE, DELETE, SELECT) is unchanged — Hibernate already handles enum conversion there.

## Call site before / after

**Before** — cast tricks and manual conversion at every call site:

```java
QLogExportJobEntity q = QLogExportJobEntity.logExportJobEntity;
Path<String> jobType = (Path<String>) (Path<?>) q.jobType;
Path<String> status = (Path<String>) (Path<?>) q.status;
Long id = queryFactory.insert(q)
    .set(jobType, entity.getJobType().name())
    .set(status, entity.getStatus().name())
    ...
    .executeWithKey(q.jobId);
```

**After** — natural, type-safe call:

```java
QLogExportJobEntity q = QLogExportJobEntity.logExportJobEntity;
Long id = queryFactory.insert(q)
    .set(q.jobType, entity.getJobType())    // auto-converted to name()
    .set(q.status, entity.getStatus())      // auto-converted to name()
    ...
    .executeWithKey(q.jobId);
```

## Scope

**In scope**
- `JPAInsertClause` / `HibernateInsertClause` on the native SQL execution path:
  - `executeWithKey(...)` / `executeWithKeys(...)`
  - `execute()` when it routes to the native path (multi-row via `addRow()`, and single-row when the JPQL path is bypassed for template-value INSERTs)
- Both `set(path, value)` and `columns(...).values(value)` call shapes
- Multi-row inserts accumulated via `addRow()`

**Out of scope**
- JPQL INSERT / UPDATE / DELETE / SELECT — Hibernate already handles enum conversion there
- Reading enum values back from result sets (all read paths use JPQL / Hibernate)
- `@Convert(converter = ...)` on enum fields — a clear runtime error steers the caller to convert the value at the call site
- `querydsl-sql` (non-JPA) — separate module, separate binding pipeline

## Design notes

- The mapping is resolved by inspecting `Path.getAnnotatedElement()` for `@Enumerated` and `@Convert`, using the same reflection surface `JpaNativeInsertSerializer` already uses to resolve `@Column` names. No new dependency on Hibernate-specific APIs.
- Conversion is a small pure step applied to the value list right after `effectiveValues(...)` and just before serialization / binding, so all four executors share a single implementation.
- Non-enum values, expression templates that do not resolve to a bare `Enum`, and columns whose target does not expose an annotated element are returned unchanged — no regression on existing paths.

## Test plan

New tests in `JPAExecuteWithKeyTest` and `HibernateExecuteWithKeyTest`:

- `@Enumerated(EnumType.STRING)` — stored as `name()`
- `@Enumerated(EnumType.ORDINAL)` — stored as `ordinal()` (single row, multi-row via `addRow()`, and `columns()`/`values()` style)
- Enum field with no `@Enumerated` — stored as `ordinal()` (JPA default)
- Mixed STRING + ORDINAL enum columns in a single row — each is converted according to its own annotation
- `@Convert(converter = ...)` on an enum field — `IllegalStateException` with an actionable message
- `@Convert` workaround (converter output supplied at the call site) — continues to work
- A second enum (`Priority`) reinforces that STRING/ORDINAL branches are generic across enum types, not specific to the `Status` enum used in the primary tests

Regression: `./mvnw -pl querydsl-libraries/querydsl-jpa -Pno-databases test` — 437 tests pass, 0 failures.