### PR TITLE
docs: use annotationProcessorPaths so query types generate on JDK 23+

### DIFF
--- a/docs/guides/code-generation.md
+++ b/docs/guides/code-generation.md
@@ -115,29 +115,34 @@ directly into compilation:
 
 ```xml
 <plugin>
+  <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-compiler-plugin</artifactId>
+  <version>3.15.0</version>
   <configuration>
-    <generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory>
+    <proc>full</proc>
+    <generatedSourcesDirectory>${project.build.directory}/generated-sources/java</generatedSourcesDirectory>
     <compilerArgs>
       <arg>-Aquerydsl.entityAccessors=true</arg>
       <arg>-Aquerydsl.useFields=false</arg>
     </compilerArgs>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>{{ site.group_id }}</groupId>
+        <artifactId>querydsl-apt</artifactId>
+        <version>{{ site.querydsl_version }}</version>
+        <classifier>jpa</classifier>
+      </path>
+    </annotationProcessorPaths>
   </configuration>
-  <dependencies>
-    <dependency>
-      <groupId>{{ site.group_id }}</groupId>
-      <artifactId>querydsl-apt</artifactId>
-      <version>{{ site.querydsl_version }}</version>
-      <classifier>jpa</classifier>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
-      <version>3.1.0</version>
-    </dependency>
-  </dependencies>
 </plugin>
 ```
+
+> **Note on JDK 23+**
+> `<proc>full</proc>` is required. Implicit annotation processing — where
+> `javac` auto-discovers processors on the compile classpath — was deprecated
+> in JDK 21 and disabled by default in JDK 23. Without it the build succeeds
+> but silently generates no query types. `annotationProcessorPaths` also keeps
+> the processor off your project's compile and runtime classpath.
 
 You need to use a proper classifier when defining the dependency on
 `{{ site.group_id }}:querydsl-apt`. The additional artifacts define the
@@ -249,18 +254,21 @@ In Maven, configure the `maven-compiler-plugin`:
 
 ```xml
 <plugin>
+  <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-compiler-plugin</artifactId>
+  <version>3.15.0</version>
   <configuration>
-    <generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory>
+    <proc>full</proc>
+    <generatedSourcesDirectory>${project.build.directory}/generated-sources/java</generatedSourcesDirectory>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>{{ site.group_id }}</groupId>
+        <artifactId>querydsl-apt</artifactId>
+        <version>{{ site.querydsl_version }}</version>
+        <classifier>general</classifier>
+      </path>
+    </annotationProcessorPaths>
   </configuration>
-  <dependencies>
-    <dependency>
-      <groupId>{{ site.group_id }}</groupId>
-      <artifactId>querydsl-apt</artifactId>
-      <version>{{ site.querydsl_version }}</version>
-      <classifier>general</classifier>
-    </dependency>
-  </dependencies>
 </plugin>
 ```
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -123,23 +123,21 @@ The old `com.mysema.maven:apt-maven-plugin` is no longer recommended. Use
 
 ```xml
 <plugin>
+  <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-compiler-plugin</artifactId>
+  <version>3.15.0</version>
   <configuration>
-    <generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory>
+    <proc>full</proc>
+    <generatedSourcesDirectory>${project.build.directory}/generated-sources/java</generatedSourcesDirectory>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>{{ site.group_id }}</groupId>
+        <artifactId>querydsl-apt</artifactId>
+        <version>{{ site.querydsl_version }}</version>
+        <classifier>jpa</classifier>
+      </path>
+    </annotationProcessorPaths>
   </configuration>
-  <dependencies>
-    <dependency>
-      <groupId>{{ site.group_id }}</groupId>
-      <artifactId>querydsl-apt</artifactId>
-      <version>{{ site.querydsl_version }}</version>
-      <classifier>jpa</classifier>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
-      <version>3.1.0</version>
-    </dependency>
-  </dependencies>
 </plugin>
 ```
 

--- a/docs/tutorials/collections.md
+++ b/docs/tutorials/collections.md
@@ -108,18 +108,21 @@ configuring the `maven-compiler-plugin`:
 
 ```xml
 <plugin>
+  <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-compiler-plugin</artifactId>
+  <version>3.15.0</version>
   <configuration>
-    <generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory>
+    <proc>full</proc>
+    <generatedSourcesDirectory>${project.build.directory}/generated-sources/java</generatedSourcesDirectory>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>{{ site.group_id }}</groupId>
+        <artifactId>querydsl-apt</artifactId>
+        <version>{{ site.querydsl_version }}</version>
+        <classifier>general</classifier>
+      </path>
+    </annotationProcessorPaths>
   </configuration>
-  <dependencies>
-    <dependency>
-      <groupId>{{ site.group_id }}</groupId>
-      <artifactId>querydsl-apt</artifactId>
-      <version>{{ site.querydsl_version }}</version>
-      <classifier>general</classifier>
-    </dependency>
-  </dependencies>
 </plugin>
 ```
 

--- a/docs/tutorials/hibernate.md
+++ b/docs/tutorials/hibernate.md
@@ -30,23 +30,26 @@ annotation processor with `HibernateAnnotationProcessor`:
 
 ```xml
 <plugin>
+  <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-compiler-plugin</artifactId>
+  <version>3.15.0</version>
   <configuration>
-    <generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory>
+    <proc>full</proc>
+    <generatedSourcesDirectory>${project.build.directory}/generated-sources/java</generatedSourcesDirectory>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>{{ site.group_id }}</groupId>
+        <artifactId>querydsl-apt</artifactId>
+        <version>{{ site.querydsl_version }}</version>
+        <classifier>hibernate</classifier>
+      </path>
+      <path>
+        <groupId>org.hibernate.orm</groupId>
+        <artifactId>hibernate-core</artifactId>
+        <version>7.4.5.Final</version>
+      </path>
+    </annotationProcessorPaths>
   </configuration>
-  <dependencies>
-    <dependency>
-      <groupId>{{ site.group_id }}</groupId>
-      <artifactId>querydsl-apt</artifactId>
-      <version>{{ site.querydsl_version }}</version>
-      <classifier>jpa</classifier>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
-      <version>3.1.0</version>
-    </dependency>
-  </dependencies>
 </plugin>
 ```
 

--- a/docs/tutorials/jpa.md
+++ b/docs/tutorials/jpa.md
@@ -32,25 +32,30 @@ during compilation:
 
 ```xml
 <plugin>
+  <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-compiler-plugin</artifactId>
+  <version>3.15.0</version>
   <configuration>
-    <generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory>
+    <proc>full</proc>
+    <generatedSourcesDirectory>${project.build.directory}/generated-sources/java</generatedSourcesDirectory>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>{{ site.group_id }}</groupId>
+        <artifactId>querydsl-apt</artifactId>
+        <version>{{ site.querydsl_version }}</version>
+        <classifier>jpa</classifier>
+      </path>
+    </annotationProcessorPaths>
   </configuration>
-  <dependencies>
-    <dependency>
-      <groupId>{{ site.group_id }}</groupId>
-      <artifactId>querydsl-apt</artifactId>
-      <version>{{ site.querydsl_version }}</version>
-      <classifier>jpa</classifier>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
-      <version>3.1.0</version>
-    </dependency>
-  </dependencies>
 </plugin>
 ```
+
+> **Note on JDK 23+**
+> `<proc>full</proc>` is required. Implicit annotation processing — where
+> `javac` auto-discovers processors on the compile classpath — was deprecated
+> in JDK 21 and disabled by default in JDK 23. Without it the build succeeds
+> but silently generates no query types. `annotationProcessorPaths` also keeps
+> the processor off your project's compile and runtime classpath.
 
 The `JPAAnnotationProcessor` finds domain types annotated with the
 `jakarta.persistence.Entity` annotation and generates query types for them.

--- a/docs/tutorials/mongodb.md
+++ b/docs/tutorials/mongodb.md
@@ -25,18 +25,31 @@ Configure the `maven-compiler-plugin` to run the Querydsl annotation processor:
 
 ```xml
 <plugin>
+  <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-compiler-plugin</artifactId>
+  <version>3.15.0</version>
   <configuration>
-    <generatedSourcesDirectory>target/generated-sources/java</generatedSourcesDirectory>
+    <proc>full</proc>
+    <generatedSourcesDirectory>${project.build.directory}/generated-sources/java</generatedSourcesDirectory>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>{{ site.group_id }}</groupId>
+        <artifactId>querydsl-apt</artifactId>
+        <version>{{ site.querydsl_version }}</version>
+        <classifier>morphia</classifier>
+      </path>
+      <path>
+        <groupId>{{ site.group_id }}</groupId>
+        <artifactId>querydsl-mongodb</artifactId>
+        <version>{{ site.querydsl_version }}</version>
+      </path>
+      <path>
+        <groupId>dev.morphia.morphia</groupId>
+        <artifactId>morphia-core</artifactId>
+        <version>2.5.3</version>
+      </path>
+    </annotationProcessorPaths>
   </configuration>
-  <dependencies>
-    <dependency>
-      <groupId>{{ site.group_id }}</groupId>
-      <artifactId>querydsl-apt</artifactId>
-      <version>{{ site.querydsl_version }}</version>
-      <classifier>morphia</classifier>
-    </dependency>
-  </dependencies>
 </plugin>
 ```
 


### PR DESCRIPTION
Fixes #1880.

The documented `maven-compiler-plugin` setup does not generate query types. I reproduced it on JDK 25 and JDK 21 with a minimal one-entity project.

## What was wrong

The docs put `querydsl-apt` in the compiler plugin's `<dependencies>` block. That populates the *plugin's* classloader, not `javac`'s annotation processor path, so the processor is never discovered. The build exits `BUILD SUCCESS` with no warning and no `Q` classes.

The reporter attributed this to implicit annotation processing being disabled in JDK 23. That is not the cause for this config — it fails on JDK 21 too, and adding `<proc>full</proc>` alone does not rescue it:

| Config | JDK 21 | JDK 25 |
|---|---|---|
| apt in plugin `<dependencies>` (what the docs said) | 0 | 0 |
| ... plus `<proc>full</proc>` | — | 0 |
| apt as a project dependency (what the examples do) | 1 | 0 |
| ... plus `<proc>full</proc>` | — | 1 |
| `annotationProcessorPaths` + `<proc>full</proc>` | — | 1 |

So there were two independent breakages: the documented config never worked, and the project-dependency style used by the examples regressed on JDK 23+. `annotationProcessorPaths` + `<proc>full</proc>` fixes both, and keeps the processor off the compile and runtime classpath.

## Changes

Converted every `querydsl-apt` snippet in `docs/` to `annotationProcessorPaths` with `<proc>full</proc>`, and added a note explaining the JDK 23+ behaviour to the JPA tutorial and the code generation guide.

Two extra fixes found while verifying each classifier:

- **`docs/tutorials/hibernate.md`** said to configure `HibernateAnnotationProcessor` but showed `<classifier>jpa</classifier>`, which selects `JPAAnnotationProcessor`. Corrected to `hibernate`, with `hibernate-core` added to the processor path (it is `test` scope on `querydsl-apt`, so it is not resolved transitively).
- **`docs/tutorials/mongodb.md`** needs `morphia-core` (`provided` scope) and `querydsl-mongodb` on the processor path. Without them the build fails with `NoClassDefFoundError: dev/morphia/annotations/Entity` and then `ClassNotFoundException: com.querydsl.mongodb.Point`.

`jakarta.persistence-api` is *not* required on the processor path — it is a compile-scope dependency of `querydsl-apt` and resolves transitively — so it has been dropped from the JPA snippets rather than carried over as the issue suggested.

## Verification

Every snippet was executed as a real Maven build on JDK 25, each generating the expected query type:

| Classifier | Processor path | Result |
|---|---|---|
| `jpa` | `querydsl-apt:jpa` | `QPerson` |
| `hibernate` | `+ hibernate-core` | `QPerson` |
| `general` | `querydsl-apt:general` | `QCat` |
| `morphia` | `+ morphia-core, querydsl-mongodb` | `QDog` |

The `compilerArgs` variant in the code generation guide was also verified to still apply alongside `annotationProcessorPaths`.

Docs-only change; no source or build files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
