### PR TITLE
perf: avoid boxing the memoized Expression hashCode

### DIFF
--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/types/ExpressionBase.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/types/ExpressionBase.java
@@ -30,7 +30,7 @@ public abstract class ExpressionBase<T> implements Expression<T> {
 
   @Nullable private transient volatile String toString;
 
-  @Nullable private transient volatile Integer hashCode;
+  private transient volatile int hashCode;
 
   public ExpressionBase(Class<? extends T> type) {
     this.type = type;
@@ -43,10 +43,12 @@ public abstract class ExpressionBase<T> implements Expression<T> {
 
   @Override
   public final int hashCode() {
-    if (hashCode == null) {
-      hashCode = accept(HashCodeVisitor.DEFAULT, null);
+    var hash = hashCode;
+    if (hash == 0) {
+      hash = accept(HashCodeVisitor.DEFAULT, null);
+      hashCode = hash;
     }
-    return hashCode;
+    return hash;
   }
 
   @Override

--- a/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/serialization/SerializerBaseTest.java
+++ b/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/serialization/SerializerBaseTest.java
@@ -13,6 +13,8 @@
  */
 package com.querydsl.core.serialization;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.querydsl.core.types.ConstantImpl;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.JavaTemplates;
@@ -37,5 +39,39 @@ class SerializerBaseTest {
     serializer.handle(ConstantImpl.create(""));
     //  custom
     serializer.handle(ExpressionUtils.template(Object.class, "xxx", ConstantImpl.create("")));
+  }
+
+  /**
+   * Constants are labelled by identity, so two equal but distinct instances are bound as two
+   * separate parameters. Boxed values outside the {@link Long} cache are distinct instances today;
+   * once the JDK migrates the wrappers to value classes (JEP 401) {@code ==} becomes state based
+   * and this collapses to a single label.
+   */
+  @Test
+  void equalButDistinctConstantsGetDistinctLabels() {
+    var serializer = new DummySerializer(new JavaTemplates());
+    Long first = 1000L;
+    Long second = 1000L;
+    assertThat(first).isNotSameAs(second).isEqualTo(second);
+
+    serializer.handle((Object) first);
+    serializer.handle((Object) second);
+
+    assertThat(serializer.getConstants()).containsExactly(first, second);
+    assertThat(serializer.getConstantToLabel()).hasSize(2);
+    assertThat(serializer).hasToString("a1a2");
+  }
+
+  @Test
+  void repeatedConstantInstanceReusesLabel() {
+    var serializer = new DummySerializer(new JavaTemplates());
+    Long value = 1000L;
+
+    serializer.handle((Object) value);
+    serializer.handle((Object) value);
+
+    assertThat(serializer.getConstants()).containsExactly(value, value);
+    assertThat(serializer.getConstantToLabel()).hasSize(1);
+    assertThat(serializer).hasToString("a1a1");
   }
 }

--- a/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/types/ExpressionBaseTest.java
+++ b/querydsl-libraries/querydsl-core/src/test/java/com/querydsl/core/types/ExpressionBaseTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.querydsl.core.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.core.types.dsl.Expressions;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ExpressionBaseTest {
+
+  /**
+   * Counts visitor dispatches so the memoization in {@link ExpressionBase#hashCode()} is
+   * observable.
+   */
+  private static final class CountingConstant extends ExpressionBase<Object>
+      implements Constant<Object> {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final Object constant;
+    private final AtomicInteger visits = new AtomicInteger();
+
+    CountingConstant(Object constant) {
+      super(Object.class);
+      this.constant = constant;
+    }
+
+    @Override
+    public Object getConstant() {
+      return constant;
+    }
+
+    @Override
+    public <R, C> R accept(Visitor<R, C> v, C context) {
+      visits.incrementAndGet();
+      return v.visit(this, context);
+    }
+  }
+
+  @Test
+  void hashCodeIsMemoized() {
+    var expr = new CountingConstant("x");
+
+    assertThat(expr.hashCode()).isEqualTo("x".hashCode());
+    assertThat(expr.hashCode()).isEqualTo("x".hashCode());
+    assertThat(expr.hashCode()).isEqualTo("x".hashCode());
+    assertThat(expr.visits).hasValue(1);
+  }
+
+  /**
+   * A computed hash of zero is indistinguishable from the "not yet computed" sentinel, so it is
+   * recomputed on every call. That is the deliberate trade-off for keeping the memo a primitive;
+   * closing it would cost a second field on every expression node.
+   */
+  @Test
+  void zeroHashIsRecomputedOnEveryCall() {
+    var expr = new CountingConstant(0);
+
+    for (var i = 0; i < 5; i++) {
+      assertThat(expr.hashCode()).isZero();
+    }
+    assertThat(expr.visits).hasValue(5);
+  }
+
+  @Test
+  void ordinaryConstantsCanHashToZero() {
+    assertThat(Expressions.constant(0).hashCode()).isZero();
+    assertThat(Expressions.constant(0L).hashCode()).isZero();
+    assertThat(Expressions.constant("").hashCode()).isZero();
+  }
+
+  /**
+   * The memo is {@code transient}, so it comes back as the zero default. Zero has to mean "not yet
+   * computed" for that to be safe: any other sentinel would make a deserialized expression report a
+   * hash of zero forever.
+   */
+  @Test
+  void deserializedExpressionRecomputesItsHash() throws Exception {
+    var original = Expressions.constant("x");
+    var expected = original.hashCode();
+
+    var bytes = new ByteArrayOutputStream();
+    try (var out = new ObjectOutputStream(bytes)) {
+      out.writeObject(original);
+    }
+    Object copy;
+    try (var in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      copy = in.readObject();
+    }
+
+    assertThat(copy).isEqualTo(original);
+    assertThat(copy.hashCode()).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
Two small, self-contained changes. Java 17 baseline is unchanged.

### Avoid boxing the memoized `Expression` hashCode

`ExpressionBase` memoized its hash in a `volatile Integer`, costing an `Integer`
allocation for every expression node that is ever hashed. Expression hashing is
not rare — it happens on every query build (join dedup, flag sets, metadata
lookups).

Switched to a `volatile int` with the usual `String.hash` sentinel, and read the
field into a local so the hot path does one volatile read instead of two.

#### On the zero sentinel

An expression whose computed hash is genuinely `0` is indistinguishable from
"not yet computed", so it re-runs `HashCodeVisitor` on every call. An earlier
revision of this description called that harmless and implied it was a
1-in-2³² curiosity, which undersold it: `HashCodeVisitor.visit(Constant)`
delegates to the constant's own `hashCode`, so `constant(0)`, `constant(0L)`,
`constant(0.0)` and `constant("")` all land on it. Thanks to @skrcode for
flagging it. `ExpressionBaseTest.ordinaryConstantsCanHashToZero` now asserts it
rather than leaving it as a claim in a PR description.

Keeping the sentinel anyway, for three reasons:

1. **The cost is bounded to the cheapest nodes.** A constant's "recompute" is
   one virtual dispatch plus a cached `Integer.valueOf`. The nodes that are
   genuinely expensive to rehash — deep `Operation` trees, `Path` metadata —
   only reach `0` at roughly 1-in-2³².

2. **Closing it costs more than it saves.** It needs a second
   `transient volatile boolean` on *every* expression node, which once
   alignment is accounted for is typically +8 bytes per node — giving back a
   meaningful share of the footprint this change is reclaiming.
   `java.lang.String` does carry exactly that flag (`hashIsZero`), but `String`
   is the case where it pays: interned strings are hashed far more often than
   they are allocated. Expression nodes are the opposite — constructed
   constantly, hashed selectively.

3. **Zero specifically has to be the sentinel.** The field is `transient`, so
   it comes back as the zero default after deserialization, and that is safe
   only because zero means "not yet computed". Any other sentinel — `-1`, say —
   would make every deserialized expression report a hash of `0` forever, since
   field initializers do not run when Java reconstructs a `Serializable`
   object. That breaks the `hashCode` contract across a serialization boundary.
   `ExpressionBaseTest.deserializedExpressionRecomputesItsHash` pins this.

`transient` semantics are otherwise unchanged: `0` after deserialization
behaves exactly as `null` did.

### Pin the memoization contract in `ExpressionBaseTest`

New test class covering the four properties above: a non-zero hash runs the
visitor exactly once, a zero hash runs it on every call, ordinary constants do
hash to zero, and a deserialized expression recomputes correctly.

The zero-hash case is a characterization test, not an aspiration — it asserts
five visitor runs for five `hashCode()` calls. If anyone later adds the
completion flag, it goes red and they have to change it deliberately rather
than by accident.

### Pin the constant-labelling contract in `SerializerBaseTest`

That test previously had a single method with no assertions at all. Added two
real tests covering `SerializerBase`'s constant labelling: equal-but-distinct
instances get distinct labels, and a repeated instance reuses its label.

This is worth having on its own, but it also guards a specific future hazard.
`SerializerBase.constantToLabel` is an `IdentityHashMap` keyed on arbitrary user
constants. JEP 401 (Value Objects, preview in JDK 28) migrates the primitive
wrappers and `LocalDate` to value classes, at which point `==` and
`identityHashCode` become state-based and that map silently starts de-duplicating
equal constants. JPA and SQL bind positionally so they are unaffected, and
querydsl-collections binds by label with the same value, so this is a change in
generated labels rather than a correctness break — but it is much easier to
notice as a red test than as a mystery diff.

### Testing

`./mvnw -pl querydsl-libraries/querydsl-{core,collections,sql,jpa} -am -Pdev test`

| module | tests | failures | errors |
| --- | --- | --- | --- |
| querydsl-core | 533 | 0 | 0 |
| querydsl-collections | 166 | 0 | 0 |
| querydsl-sql | 3952 | 0 | 0 |
| querydsl-jpa | 3207 | 0 | 0 |

`BUILD SUCCESS`. (An earlier revision of this description reported "3207 tests"
as the total across all four modules; that figure was in fact the jpa module
alone.)
