### PR TITLE
docs: document the identity contract of the serializer constant labels

### DIFF
--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/support/SerializerBase.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/support/SerializerBase.java
@@ -66,6 +66,19 @@ public abstract class SerializerBase<S extends SerializerBase<S>> implements Vis
 
   protected final List<Object> constants = new ArrayList<>();
 
+  /**
+   * Labels assigned to the constants collected in {@link #constants}, keyed by <i>identity</i>.
+   *
+   * <p>Two equal but distinct constant instances therefore receive two distinct labels, and the
+   * same instance encountered twice reuses its label. Dialects that bind positionally are
+   * unaffected by this, but a dialect that binds by label depends on it.
+   *
+   * <p>This is a deliberate identity dependency on values supplied by the caller. JEP 401 (Value
+   * Objects, preview in JDK 28) migrates the primitive wrappers and {@code LocalDate} to value
+   * classes, for which {@code ==} and {@code identityHashCode} become state based; under that JDK
+   * this map starts collapsing equal constants onto a single label. {@code SerializerBaseTest} pins
+   * the current behaviour.
+   */
   protected final Map<Object, String> constantToLabel = new IdentityHashMap<>();
 
   @SuppressWarnings("unchecked")
@@ -98,6 +111,13 @@ public abstract class SerializerBase<S extends SerializerBase<S>> implements Vis
     return constantPrefix;
   }
 
+  /**
+   * Get the label assigned to each collected constant.
+   *
+   * <p>The returned map is keyed by identity, not by equality; see {@link #constantToLabel}.
+   *
+   * @return the live label map
+   */
   public Map<Object, String> getConstantToLabel() {
     return constantToLabel;
   }


### PR DESCRIPTION
Documentation only, no behaviour change.

`SerializerBase.constantToLabel` is an `IdentityHashMap` keyed on arbitrary
constants supplied by the caller, and `getConstantToLabel()` exposes it as public
API. Nothing said so, which matters in two directions:

- A dialect that overrides `serializeConstant` to bind **by label** depends on
  the identity keying; one that binds positionally (JPA and SQL both do) does not.
- It is a deliberate identity dependency on user values. JEP 401 (Value Objects,
  preview in JDK 28) migrates the primitive wrappers and `LocalDate` to value
  classes, at which point `==` and `identityHashCode` become state-based and the
  map starts collapsing equal-but-distinct constants onto one label.

Added javadoc on the field and the accessor recording both, and pointed at
`SerializerBaseTest`, which pins the current behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnNBe1GoG2SxfU3FN7bcAA
