### PR TITLE
docs: annotate QueryModifiers and SchemaAndTable as @Immutable

### DIFF
--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/QueryModifiers.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/QueryModifiers.java
@@ -13,6 +13,7 @@
  */
 package com.querydsl.core;
 
+import com.querydsl.core.annotations.Immutable;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.jetbrains.annotations.Range;
  *
  * @author tiwe
  */
+@Immutable
 public final class QueryModifiers implements Serializable {
 
   @Serial private static final long serialVersionUID = 2934344588433680339L;

--- a/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/SchemaAndTable.java
+++ b/querydsl-libraries/querydsl-sql/src/main/java/com/querydsl/sql/SchemaAndTable.java
@@ -13,10 +13,12 @@
  */
 package com.querydsl.sql;
 
+import com.querydsl.core.annotations.Immutable;
 import java.io.Serializable;
 import java.util.Objects;
 
 /** {@code SchemaAndTable} combines schema and table into a single value type */
+@Immutable
 public class SchemaAndTable implements Serializable {
 
   private final String schema, table;


### PR DESCRIPTION
Annotation only, no behaviour change.

`@Immutable` is `RetentionPolicy.CLASS` and marks the types in this codebase
that are already value-shaped: final fields only, value-based `equals`, no
identity dependence. `PathMetadata`, `JoinExpression`, `JoinFlag`,
`OrderSpecifier`, `Template` and its `Element` subclasses, `ConstantImpl` and
friends all carry it.

Two types that meet the same bar were missing it:

- `QueryModifiers` — final class, two final fields, value `equals`/`hashCode`
- `SchemaAndTable` — two final fields, value `equals`/`hashCode`

This keeps the annotated set an accurate inventory of the value-shaped types,
which is the list you would work from for any future value-class migration
(JEP 401), and it is useful documentation regardless.

Deliberately not included, since both are breaking changes and belong in their
own discussion:

- marking these `final` — nothing in the repo extends either, but downstream
  code may
- converting them to records — changes accessor names (`getSchema()` →
  `schema()`) and the serialized form

### Testing

`./mvnw -Pdev -pl :querydsl-sql -am test`: 3952 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnNBe1GoG2SxfU3FN7bcAA
