### PR TITLE
ci: add a non-blocking JDK 28 early-access preview canary job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -88,6 +88,40 @@ jobs:
         shell: bash
         run: ./mvnw -ntp -B verify -Pno-databases -Dtoolchain.skip=true
 
+  # Experimental canary, never blocking. Runs the database-independent suite on a
+  # JDK 28 early-access build with preview features enabled at runtime.
+  #
+  # JEP 401 (Value Objects) migrates the primitive wrappers and LocalDate to value
+  # classes under --enable-preview, which makes == and identityHashCode state
+  # based for them. Querydsl keys SerializerBase.constantToLabel and the alias
+  # proxy cache by identity on values supplied by the caller, so this job is where
+  # that change should surface first rather than in a user's application.
+  #
+  # Deliberately excluded from the aggregate `build` check and marked
+  # continue-on-error: a broken EA build, a withdrawn EA release or a genuine
+  # preview regression must never block a PR.
+  jdk28-preview:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 28 early access
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "28-ea"
+          cache: "maven"
+      - name: Report JDK version
+        run: java -version
+      - name: Test with preview features enabled
+        run: >
+          ./mvnw -ntp -B verify -Pno-databases
+          -Dtoolchain.skip=true
+          -Deasyjacoco.skip=true
+          -DargLine=--enable-preview
+
   embedded:
     if: ${{ !github.event.pull_request.draft }}
     needs: compile


### PR DESCRIPTION
Adds one CI job. No source changes, Java 17 baseline untouched.

JEP 401 (Value Objects) is a preview feature in JDK 28. With `--enable-preview`
the primitive wrappers and `LocalDate` become value classes, so `==` and
`identityHashCode` turn state-based for them. Querydsl keys
`SerializerBase.constantToLabel` and the alias proxy cache by identity on values
supplied by the caller, so that change lands on us before it lands on anything
we control. Better to see it in CI than in an issue report.

The job runs the `no-databases` suite on a JDK 28 EA build with preview enabled
at runtime, using `-Dtoolchain.skip=true` the same way the existing `windows` job
does.

**It cannot block anything.** It is marked `continue-on-error` and is
deliberately left out of the aggregate `build` check's `needs` list, so a broken
EA build, a withdrawn EA release, or a real preview regression all fail quietly.

### Caveat worth stating plainly

I could not verify this locally — JDK 28 EA downloads are unreachable from my
environment, so this job's first real run is the one on this PR. Two things I
was not able to confirm in advance:

- whether `actions/setup-java` resolves `28-ea` for the `temurin` distribution
- whether the JDK's migrated value classes actually change `==` behaviour with
  only runtime `--enable-preview`, given our classes are compiled without preview

If the job goes green and nothing changes, that is a useful result too: it means
the migration is not yet observable and the canary is in place for when it is.
Happy to drop or rework this if the first run shows the setup is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnNBe1GoG2SxfU3FN7bcAA
