### PR TITLE
Annotate fetchFirst method with @Nullable

### DIFF
--- a/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/support/FetchableQueryBase.java
+++ b/querydsl-libraries/querydsl-core/src/main/java/com/querydsl/core/support/FetchableQueryBase.java
@@ -46,7 +46,7 @@ public abstract class FetchableQueryBase<T, Q extends FetchableQueryBase<T, Q>> 
   }
 
   @Override
-  public final T fetchFirst() {
+  public @Nullable final T fetchFirst() {
     return limit(1).fetchOne();
   }
 


### PR DESCRIPTION
Add @Nullable annotation to fetchFirst method,because IDEA mistakenly thinks the return value won't be null.